### PR TITLE
feat: metrics history, log-spike alerts, namespace bulk ops and telegram autocomplete (v0.7.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "alter"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "A process manager for your developers — run and manage any application"
 
@@ -58,4 +58,11 @@ windows = { version = "0.58", features = [
 opt-level     = 3
 lto           = true
 codegen-units = 1
+strip         = true
+
+# Faster release builds for day-to-day use — thin LTO, parallel codegen
+[profile.release-fast]
+inherits      = "release"
+lto           = "thin"
+codegen-units = 8
 strip         = true

--- a/manifests/t/thechandanbhagat/alter/0.4.0/thechandanbhagat.alter.installer.yaml
+++ b/manifests/t/thechandanbhagat/alter/0.4.0/thechandanbhagat.alter.installer.yaml
@@ -22,6 +22,6 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/thechandanbhagat/alter-pm/releases/download/v0.4.0/alter-0.4.0-windows-x64-setup.exe
   InstallerSha256: 3FA0250167903C8A7D96873BBFAA49B24D32530A657A231A8C474C296EE1C7BB
+ReleaseDate: 2026-03-02
 ManifestType: installer
 ManifestVersion: 1.10.0
-ReleaseDate: 2026-03-02

--- a/manifests/t/thechandanbhagat/alter/0.5.0/thechandanbhagat.alter.installer.yaml
+++ b/manifests/t/thechandanbhagat/alter/0.5.0/thechandanbhagat.alter.installer.yaml
@@ -18,6 +18,6 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/thechandanbhagat/alter-pm/releases/download/v0.5.0/alter-0.5.0-windows-x64-setup.exe
   InstallerSha256: B7876DF61519BC5181CFBA29453C1FC33C11AB8494BD1EF89F0F06C9B3D77711
+ReleaseDate: 2026-03-07
 ManifestType: installer
 ManifestVersion: 1.10.0
-ReleaseDate: 2026-03-07

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -20,6 +20,7 @@ pub fn router(state: Arc<DaemonState>) -> Router {
         .nest("/telegram", routes::telegram::router(Arc::clone(&state)))
         .nest("/ports", routes::ports::router())
         .merge(routes::metrics::router(Arc::clone(&state)))
+        .merge(routes::log_alerts::router())
         .route_layer(axum_middleware::from_fn_with_state(
             Arc::clone(&state),
             middleware::require_auth,

--- a/src/api/routes/log_alerts.rs
+++ b/src/api/routes/log_alerts.rs
@@ -1,0 +1,26 @@
+// @group APIEndpoints : Log alert config — GET/PUT /log-alerts
+
+use crate::config::log_alert_config::{self, LogAlertConfig};
+use axum::{http::StatusCode, routing::get, Json, Router};
+use serde_json::{json, Value};
+
+pub fn router() -> Router {
+    Router::new().route("/log-alerts", get(get_config).put(put_config))
+}
+
+// @group APIEndpoints > LogAlerts : GET /log-alerts — return current log alert settings
+async fn get_config() -> Json<Value> {
+    let cfg = log_alert_config::load();
+    Json(json!(cfg))
+}
+
+// @group APIEndpoints > LogAlerts : PUT /log-alerts — save updated log alert settings
+async fn put_config(Json(body): Json<LogAlertConfig>) -> (StatusCode, Json<Value>) {
+    match log_alert_config::save(&body) {
+        Ok(_) => (StatusCode::OK, Json(json!(body))),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e.to_string() })),
+        ),
+    }
+}

--- a/src/api/routes/mod.rs
+++ b/src/api/routes/mod.rs
@@ -3,6 +3,7 @@
 pub mod ai;
 pub mod auth;
 pub mod ecosystem;
+pub mod log_alerts;
 pub mod logs;
 pub mod metrics;
 pub mod notifications;

--- a/src/api/routes/processes.rs
+++ b/src/api/routes/processes.rs
@@ -27,9 +27,15 @@ pub fn router(state: Arc<DaemonState>) -> Router {
         .route("/{id}/logs", get(get_logs).delete(delete_logs))
         .route("/{id}/logs/dates", get(get_log_dates))
         .route("/{id}/logs/stream", get(stream_logs))
+        .route("/{id}/metrics/history", get(get_metrics_history))
+        .route("/{id}/logs/stats", get(get_log_stats))
         .route("/{id}/cron/history", get(get_cron_history))
         .route("/{id}/envfiles", get(list_envfiles))
         .route("/{id}/envfile", get(get_envfile).put(put_envfile))
+        // Namespace bulk operations
+        .route("/namespace/{ns}/start", post(start_namespace_processes))
+        .route("/namespace/{ns}/stop", post(stop_namespace_processes))
+        .route("/namespace/{ns}/restart", post(restart_namespace_processes))
         .with_state(state)
 }
 
@@ -354,6 +360,33 @@ async fn get_cron_history(
     Ok(Json(json!({ "runs": info.cron_run_history })))
 }
 
+// @group APIEndpoints > LogStats : GET /processes/:id/logs/stats — full-day 5-minute log volume buckets read from disk
+async fn get_log_stats(
+    State(state): State<Arc<DaemonState>>,
+    Path(id_str): Path<String>,
+) -> Result<Json<Value>, ApiError> {
+    let id = resolve(&state, &id_str).await?;
+    let info = state.manager.get(id).await.map_err(ApiError::from)?;
+    let log_dir = crate::config::paths::process_log_dir(&info.name);
+    let buckets = tokio::task::spawn_blocking(move || {
+        crate::logging::reader::read_log_stats_today(&log_dir)
+    })
+    .await
+    .map_err(|e| ApiError::from(anyhow::anyhow!("task join error: {e}")))?
+    .map_err(ApiError::from)?;
+    Ok(Json(json!({ "buckets": buckets })))
+}
+
+// @group APIEndpoints > Metrics : GET /processes/:id/metrics/history — rolling CPU + memory samples
+async fn get_metrics_history(
+    State(state): State<Arc<DaemonState>>,
+    Path(id_str): Path<String>,
+) -> Result<Json<Value>, ApiError> {
+    let id = resolve(&state, &id_str).await?;
+    let samples = state.manager.get_metrics_history(id).await;
+    Ok(Json(json!({ "samples": samples })))
+}
+
 // @group APIEndpoints > Logs : DELETE /processes/:id/logs — remove all log files for a process
 async fn delete_logs(
     State(state): State<Arc<DaemonState>>,
@@ -437,6 +470,72 @@ async fn put_envfile(
         .map_err(|e| ApiError::internal(format!("failed to write env file: {e}")))?;
 
     Ok(Json(json!({ "success": true, "path": env_path.to_string_lossy(), "filename": filename })))
+}
+
+// @group APIEndpoints > Namespace : POST /processes/namespace/:ns/start — start all stopped processes in namespace
+async fn start_namespace_processes(
+    State(state): State<Arc<DaemonState>>,
+    Path(ns): Path<String>,
+) -> Json<Value> {
+    use crate::notifications::sender::ProcessEvent;
+    let infos = state.manager.start_namespace(&ns).await;
+    let s = state.clone();
+    tokio::spawn(async move { if let Err(e) = s.save_to_disk().await { tracing::warn!("auto-save failed: {e}"); } });
+    if !infos.is_empty() {
+        let infos_clone = infos.clone();
+        let ns_clone = ns.clone();
+        let notif = Arc::clone(&state.notifications);
+        tokio::spawn(async move {
+            crate::telegram::commands::fire_telegram_namespace_notification(&ns_clone, ProcessEvent::Started, &infos_clone).await;
+            let store = notif.read().await;
+            crate::notifications::sender::fire_namespace_event(&store, &ns_clone, &infos_clone, ProcessEvent::Started).await;
+        });
+    }
+    Json(json!({ "namespace": ns, "started": infos.len(), "processes": infos }))
+}
+
+// @group APIEndpoints > Namespace : POST /processes/namespace/:ns/stop — stop all running processes in namespace
+async fn stop_namespace_processes(
+    State(state): State<Arc<DaemonState>>,
+    Path(ns): Path<String>,
+) -> Json<Value> {
+    use crate::notifications::sender::ProcessEvent;
+    let infos = state.manager.stop_namespace(&ns).await;
+    let s = state.clone();
+    tokio::spawn(async move { if let Err(e) = s.save_to_disk().await { tracing::warn!("auto-save failed: {e}"); } });
+    if !infos.is_empty() {
+        let infos_clone = infos.clone();
+        let ns_clone = ns.clone();
+        let notif = Arc::clone(&state.notifications);
+        tokio::spawn(async move {
+            crate::telegram::commands::fire_telegram_namespace_notification(&ns_clone, ProcessEvent::Stopped, &infos_clone).await;
+            let store = notif.read().await;
+            crate::notifications::sender::fire_namespace_event(&store, &ns_clone, &infos_clone, ProcessEvent::Stopped).await;
+        });
+    }
+    Json(json!({ "namespace": ns, "stopped": infos.len(), "processes": infos }))
+}
+
+// @group APIEndpoints > Namespace : POST /processes/namespace/:ns/restart — restart all processes in namespace
+async fn restart_namespace_processes(
+    State(state): State<Arc<DaemonState>>,
+    Path(ns): Path<String>,
+) -> Json<Value> {
+    use crate::notifications::sender::ProcessEvent;
+    let infos = state.manager.restart_namespace(&ns).await;
+    let s = state.clone();
+    tokio::spawn(async move { if let Err(e) = s.save_to_disk().await { tracing::warn!("auto-save failed: {e}"); } });
+    if !infos.is_empty() {
+        let infos_clone = infos.clone();
+        let ns_clone = ns.clone();
+        let notif = Arc::clone(&state.notifications);
+        tokio::spawn(async move {
+            crate::telegram::commands::fire_telegram_namespace_notification(&ns_clone, ProcessEvent::Restarted, &infos_clone).await;
+            let store = notif.read().await;
+            crate::notifications::sender::fire_namespace_event(&store, &ns_clone, &infos_clone, ProcessEvent::Restarted).await;
+        });
+    }
+    Json(json!({ "namespace": ns, "restarted": infos.len(), "processes": infos }))
 }
 
 async fn resolve(state: &DaemonState, id_str: &str) -> Result<Uuid, ApiError> {

--- a/src/config/log_alert_config.rs
+++ b/src/config/log_alert_config.rs
@@ -1,0 +1,47 @@
+// @group Configuration : Log alert config — stored at %APPDATA%\alter-pm2\log_alerts.json
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+// @group Types > LogAlertConfig : Threshold-based stderr spike notification settings
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogAlertConfig {
+    /// Whether log-spike alerts are active
+    pub enabled: bool,
+    /// Fire an alert when stderr lines in a 5-minute bucket reach or exceed this count
+    pub stderr_threshold: u64,
+    /// Minimum minutes between repeated alerts for the same process (spam guard)
+    pub cooldown_mins: u32,
+}
+
+impl Default for LogAlertConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            stderr_threshold: 10,
+            cooldown_mins: 15,
+        }
+    }
+}
+
+// @group Configuration : Load log alert config from disk (returns default if missing)
+pub fn load() -> LogAlertConfig {
+    let path = crate::config::paths::data_dir().join("log_alerts.json");
+    match std::fs::read_to_string(&path) {
+        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+        Err(_) => LogAlertConfig::default(),
+    }
+}
+
+// @group Configuration : Persist log alert config to disk (atomic write)
+pub fn save(config: &LogAlertConfig) -> Result<()> {
+    let path = crate::config::paths::data_dir().join("log_alerts.json");
+    let content = serde_json::to_string_pretty(config)?;
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, &content)?;
+    if std::fs::rename(&tmp, &path).is_err() {
+        let _ = std::fs::remove_file(&tmp);
+        std::fs::write(&path, &content)?;
+    }
+    Ok(())
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,6 +4,7 @@ pub mod auth_config;
 pub mod daemon_config;
 pub mod ecosystem;
 pub mod env_file;
+pub mod log_alert_config;
 pub mod notification_store;
 pub mod paths;
 pub mod telegram_config;

--- a/src/logging/reader.rs
+++ b/src/logging/reader.rs
@@ -2,7 +2,7 @@
 // @group BusinessLogic > DatedLogs : Read lines from daily-rotated dated log files
 
 use anyhow::Result;
-use chrono::NaiveDate;
+use chrono::{Local, NaiveDate, TimeZone, Utc};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
@@ -69,6 +69,83 @@ pub fn list_log_dates(log_dir: &Path) -> Result<Vec<NaiveDate>> {
     // Newest first
     dates.sort_by(|a, b| b.cmp(a));
     Ok(dates)
+}
+
+// @group BusinessLogic > LogStats : One 5-minute bucket of log line counts for today's chart
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DayLogBucket {
+    /// UTC ISO-8601 start of this 5-minute window
+    pub window_start: String,
+    pub stdout_count: u64,
+    pub stderr_count: u64,
+}
+
+// @group BusinessLogic > LogStats : Read today's out.log + err.log, bucket lines by 5-min intervals
+/// Scans the full log files (no line limit) so the chart covers the entire day even
+/// across daemon restarts. Lines whose timestamp does not match today are ignored.
+pub fn read_log_stats_today(log_dir: &Path) -> Result<Vec<DayLogBucket>> {
+    use std::collections::BTreeMap;
+
+    let today_local = Local::now().date_naive();
+    let bucket_secs: i64 = 300; // 5 minutes
+
+    // BTreeMap keyed by bucket_start Unix timestamp — gives us sorted, gapless output
+    let mut buckets: BTreeMap<i64, (u64, u64)> = BTreeMap::new();
+
+    for (path, is_stdout) in [
+        (log_dir.join("out.log"), true),
+        (log_dir.join("err.log"), false),
+    ] {
+        if !path.exists() {
+            continue;
+        }
+        let file = File::open(&path)?;
+        let reader = BufReader::new(file);
+
+        for raw in reader.lines().map_while(Result::ok) {
+            let (ts_str, _) = parse_log_line(&raw);
+            if ts_str.is_empty() {
+                continue;
+            }
+            // Parse the ISO-8601 UTC timestamp written by the LogWriter
+            let Ok(dt_utc) = ts_str.parse::<chrono::DateTime<Utc>>() else {
+                continue;
+            };
+            // Only include lines from today (in local time)
+            let dt_local = dt_utc.with_timezone(&Local);
+            if dt_local.date_naive() != today_local {
+                continue;
+            }
+            // Floor to the nearest 5-minute bucket
+            let secs = dt_utc.timestamp();
+            let bucket_key = secs - (secs % bucket_secs);
+            let entry = buckets.entry(bucket_key).or_insert((0, 0));
+            if is_stdout {
+                entry.0 += 1;
+            } else {
+                entry.1 += 1;
+            }
+        }
+    }
+
+    // Convert to serialisable structs, preserving chronological order
+    let result = buckets
+        .into_iter()
+        .map(|(key, (out, err))| {
+            let window_start = Utc
+                .timestamp_opt(key, 0)
+                .single()
+                .map(|dt| dt.to_rfc3339())
+                .unwrap_or_default();
+            DayLogBucket {
+                window_start,
+                stdout_count: out,
+                stderr_count: err,
+            }
+        })
+        .collect();
+
+    Ok(result)
 }
 
 // @group Utilities : Extract [ISO8601] timestamp prefix from a disk log line

--- a/src/models/log_stats.rs
+++ b/src/models/log_stats.rs
@@ -1,0 +1,92 @@
+// @group Types : Per-process log volume tracking — stdout/stderr counts in 5-minute buckets
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+
+// @group Constants : Bucket width in seconds (5 minutes)
+pub const LOG_BUCKET_SECS: i64 = 300;
+// @group Constants : Maximum completed buckets retained per process (288 × 5 min = 24 h)
+pub const MAX_LOG_STAT_BUCKETS: usize = 288;
+
+// @group Types > LogStatsBucket : Completed 5-minute window with stdout + stderr line counts
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogStatsBucket {
+    /// UTC start of this 5-minute window
+    pub window_start: DateTime<Utc>,
+    /// Lines written to stdout during this window
+    pub stdout_count: u64,
+    /// Lines written to stderr during this window
+    pub stderr_count: u64,
+}
+
+// @group BusinessLogic > LogStatsState : Mutable accumulator for live log counting
+pub struct LogStatsState {
+    /// Start of the currently open bucket
+    pub current_bucket_start: DateTime<Utc>,
+    pub current_stdout: u64,
+    pub current_stderr: u64,
+    /// Completed historical buckets (oldest first)
+    pub history: VecDeque<LogStatsBucket>,
+}
+
+impl LogStatsState {
+    pub fn new() -> Self {
+        Self {
+            current_bucket_start: bucket_floor(Utc::now()),
+            current_stdout: 0,
+            current_stderr: 0,
+            history: VecDeque::new(),
+        }
+    }
+
+    // @group BusinessLogic > LogStatsState : Record one log line; flush bucket if the window has rolled over
+    pub fn record(&mut self, is_stdout: bool) {
+        let now = Utc::now();
+        let expected_start = bucket_floor(now);
+
+        if expected_start > self.current_bucket_start {
+            // The 5-minute window has elapsed — push the completed bucket
+            if self.current_stdout > 0 || self.current_stderr > 0 {
+                self.history.push_back(LogStatsBucket {
+                    window_start: self.current_bucket_start,
+                    stdout_count: self.current_stdout,
+                    stderr_count: self.current_stderr,
+                });
+                if self.history.len() > MAX_LOG_STAT_BUCKETS {
+                    self.history.pop_front();
+                }
+            }
+            self.current_bucket_start = expected_start;
+            self.current_stdout = 0;
+            self.current_stderr = 0;
+        }
+
+        if is_stdout {
+            self.current_stdout += 1;
+        } else {
+            self.current_stderr += 1;
+        }
+    }
+
+    // @group BusinessLogic > LogStatsState : Return all completed buckets plus the current open one
+    pub fn snapshot(&self) -> Vec<LogStatsBucket> {
+        let mut out: Vec<LogStatsBucket> = self.history.iter().cloned().collect();
+        // Always append the current open bucket so callers see live data
+        if self.current_stdout > 0 || self.current_stderr > 0 {
+            out.push(LogStatsBucket {
+                window_start: self.current_bucket_start,
+                stdout_count: self.current_stdout,
+                stderr_count: self.current_stderr,
+            });
+        }
+        out
+    }
+}
+
+// @group Utilities : Floor a timestamp down to the nearest 5-minute boundary
+fn bucket_floor(ts: DateTime<Utc>) -> DateTime<Utc> {
+    let secs = ts.timestamp();
+    let floored = secs - (secs % LOG_BUCKET_SECS);
+    DateTime::from_timestamp(floored, 0).unwrap_or(ts)
+}

--- a/src/models/metric_sample.rs
+++ b/src/models/metric_sample.rs
@@ -1,0 +1,15 @@
+// @group Types : Point-in-time CPU + memory snapshot recorded by the metrics sampler
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+// @group Types > MetricSample : Single sampled data point for a running process
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetricSample {
+    /// When this sample was taken (UTC)
+    pub timestamp: DateTime<Utc>,
+    /// CPU usage percentage (0–100 per core)
+    pub cpu_percent: f32,
+    /// Resident memory in bytes
+    pub memory_bytes: u64,
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -3,6 +3,8 @@
 pub mod ai;
 pub mod api_types;
 pub mod cron_run;
+pub mod log_stats;
+pub mod metric_sample;
 pub mod notification;
 pub mod process_info;
 pub mod process_status;

--- a/src/notifications/sender.rs
+++ b/src/notifications/sender.rs
@@ -43,6 +43,132 @@ impl ProcessEvent {
     }
 }
 
+// @group BusinessLogic > FireLogAlert : Send a log-spike alert through all configured global channels
+pub async fn fire_log_alert(
+    store: &NotificationsStore,
+    proc: &ProcessInfo,
+    stderr_count: u64,
+    threshold: u64,
+) {
+    let effective = store.global.clone();
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .unwrap_or_default();
+
+    if let Some(wh) = &effective.webhook {
+        if wh.enabled && !wh.url.is_empty() {
+            let payload = serde_json::json!({
+                "event": "log_alert",
+                "timestamp": Utc::now().to_rfc3339(),
+                "process": { "id": proc.id, "name": proc.name, "namespace": proc.namespace },
+                "stderr_count": stderr_count,
+                "threshold": threshold,
+            });
+            let _ = client.post(&wh.url).json(&payload).send().await;
+        }
+    }
+
+    if let Some(sl) = &effective.slack {
+        if sl.enabled && !sl.webhook_url.is_empty() {
+            let text = format!(
+                "⚠️ *{}* — {} stderr lines in the last 5 min (threshold: {})",
+                proc.name, stderr_count, threshold
+            );
+            let mut payload = serde_json::json!({
+                "text": text,
+                "attachments": [{
+                    "color": "#ef4444",
+                    "fields": [
+                        { "title": "Process",    "value": &proc.name,      "short": true },
+                        { "title": "Namespace",  "value": &proc.namespace, "short": true },
+                        { "title": "Stderr",     "value": stderr_count.to_string(), "short": true },
+                        { "title": "Threshold",  "value": threshold.to_string(),    "short": true },
+                    ],
+                    "footer": "alter-pm2 · log alert",
+                    "ts": Utc::now().timestamp(),
+                }]
+            });
+            if let Some(ch) = &sl.channel {
+                if !ch.is_empty() {
+                    payload["channel"] = serde_json::Value::String(ch.clone());
+                }
+            }
+            let _ = client.post(&sl.webhook_url).json(&payload).send().await;
+        }
+    }
+
+    if let Some(tm) = &effective.teams {
+        if tm.enabled && !tm.webhook_url.is_empty() {
+            let payload = serde_json::json!({
+                "@type": "MessageCard",
+                "@context": "http://schema.org/extensions",
+                "summary": format!("{} — log alert", proc.name),
+                "themeColor": "ef4444",
+                "title": format!("⚠️ {} — log spike detected", proc.name),
+                "sections": [{ "facts": [
+                    { "name": "Process",    "value": &proc.name },
+                    { "name": "Namespace",  "value": &proc.namespace },
+                    { "name": "Stderr count", "value": stderr_count.to_string() },
+                    { "name": "Threshold",  "value": threshold.to_string() },
+                    { "name": "Timestamp",  "value": Utc::now().to_rfc3339() },
+                ]}]
+            });
+            let _ = client.post(&tm.webhook_url).json(&payload).send().await;
+        }
+    }
+}
+
+// @group BusinessLogic > FireNamespaceEvent : Fire one summary notification for a bulk namespace operation
+pub async fn fire_namespace_event(
+    store: &NotificationsStore,
+    namespace: &str,
+    processes: &[ProcessInfo],
+    event: ProcessEvent,
+) {
+    if processes.is_empty() {
+        return;
+    }
+
+    let ns_config = store.namespaces.get(namespace);
+    let effective = merge_configs(None, ns_config, Some(&store.global));
+
+    let should_fire = match event {
+        ProcessEvent::Started    => effective.events.on_start,
+        ProcessEvent::Stopped    => effective.events.on_stop,
+        ProcessEvent::Crashed    => effective.events.on_crash,
+        ProcessEvent::Restarted  => effective.events.on_restart,
+        ProcessEvent::CronRun    => effective.events.on_cron_run,
+        ProcessEvent::CronFailed => effective.events.on_cron_fail,
+    };
+
+    if !should_fire {
+        return;
+    }
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .unwrap_or_default();
+
+    if let Some(wh) = &effective.webhook {
+        if wh.enabled && !wh.url.is_empty() {
+            send_namespace_webhook(&client, wh, namespace, processes, event).await;
+        }
+    }
+    if let Some(sl) = &effective.slack {
+        if sl.enabled && !sl.webhook_url.is_empty() {
+            send_namespace_slack(&client, sl, namespace, processes, event).await;
+        }
+    }
+    if let Some(tm) = &effective.teams {
+        if tm.enabled && !tm.webhook_url.is_empty() {
+            send_namespace_teams(&client, tm, namespace, processes, event).await;
+        }
+    }
+}
+
 // @group BusinessLogic > FireEvent : Resolve effective config and dispatch all enabled channels
 pub async fn fire_event(store: &NotificationsStore, proc: &ProcessInfo, event: ProcessEvent) {
     // Cascade: process → namespace → global (first non-None wins per channel)
@@ -204,5 +330,112 @@ async fn send_teams(client: &reqwest::Client, tm: &TeamsTarget, proc: &ProcessIn
 
     if let Err(e) = client.post(&tm.webhook_url).json(&payload).send().await {
         tracing::warn!("Teams notification failed for '{}': {e}", proc.name);
+    }
+}
+
+// @group BusinessLogic > SendNamespaceWebhook : POST namespace-level JSON payload to webhook URL
+async fn send_namespace_webhook(
+    client: &reqwest::Client,
+    wh: &WebhookTarget,
+    namespace: &str,
+    processes: &[ProcessInfo],
+    event: ProcessEvent,
+) {
+    let names: Vec<&str> = processes.iter().map(|p| p.name.as_str()).collect();
+    let payload = json!({
+        "event":     event.label(),
+        "timestamp": Utc::now().to_rfc3339(),
+        "namespace": namespace,
+        "count":     processes.len(),
+        "processes": names,
+    });
+    if let Err(e) = client.post(&wh.url).json(&payload).send().await {
+        tracing::warn!("webhook namespace notification failed for ns '{}': {e}", namespace);
+    }
+}
+
+// @group BusinessLogic > SendNamespaceSlack : POST Slack-formatted namespace summary card
+async fn send_namespace_slack(
+    client: &reqwest::Client,
+    sl: &SlackTarget,
+    namespace: &str,
+    processes: &[ProcessInfo],
+    event: ProcessEvent,
+) {
+    let color = match event {
+        ProcessEvent::Started    => "#36a64f",
+        ProcessEvent::Stopped    => "#aaaaaa",
+        ProcessEvent::Crashed    => "#ff0000",
+        ProcessEvent::Restarted  => "#f0ad4e",
+        ProcessEvent::CronRun    => "#fbbf24",
+        ProcessEvent::CronFailed => "#ef4444",
+    };
+    let names: Vec<&str> = processes.iter().map(|p| p.name.as_str()).collect();
+    let text = format!(
+        "{} *{}* — {} process{} {}",
+        event.emoji(),
+        namespace,
+        processes.len(),
+        if processes.len() == 1 { "" } else { "es" },
+        event.label(),
+    );
+    let mut payload = json!({
+        "text": text,
+        "attachments": [{
+            "color": color,
+            "fields": [
+                { "title": "Namespace", "value": namespace,          "short": true },
+                { "title": "Event",     "value": event.label(),      "short": true },
+                { "title": "Processes", "value": names.join(", "),   "short": false },
+            ],
+            "footer": "alter-pm2",
+            "ts": Utc::now().timestamp(),
+        }]
+    });
+    if let Some(channel) = &sl.channel {
+        if !channel.is_empty() {
+            payload["channel"] = Value::String(channel.clone());
+        }
+    }
+    if let Err(e) = client.post(&sl.webhook_url).json(&payload).send().await {
+        tracing::warn!("Slack namespace notification failed for ns '{}': {e}", namespace);
+    }
+}
+
+// @group BusinessLogic > SendNamespaceTeams : POST Microsoft Teams namespace summary card
+async fn send_namespace_teams(
+    client: &reqwest::Client,
+    tm: &TeamsTarget,
+    namespace: &str,
+    processes: &[ProcessInfo],
+    event: ProcessEvent,
+) {
+    let names: Vec<&str> = processes.iter().map(|p| p.name.as_str()).collect();
+    let summary = format!("Namespace {} — {} {}", namespace, event.label(), processes.len());
+    let payload = json!({
+        "@type":      "MessageCard",
+        "@context":   "http://schema.org/extensions",
+        "summary":    &summary,
+        "themeColor": match event {
+            ProcessEvent::Crashed    => "FF0000",
+            ProcessEvent::Started    => "36a64f",
+            ProcessEvent::Restarted  => "f0ad4e",
+            ProcessEvent::Stopped    => "aaaaaa",
+            ProcessEvent::CronRun    => "fbbf24",
+            ProcessEvent::CronFailed => "ef4444",
+        },
+        "title": format!("{} {}", event.emoji(), &summary),
+        "sections": [{
+            "facts": [
+                { "name": "Namespace",  "value": namespace },
+                { "name": "Event",      "value": event.label() },
+                { "name": "Count",      "value": processes.len().to_string() },
+                { "name": "Processes",  "value": names.join(", ") },
+                { "name": "Timestamp",  "value": Utc::now().to_rfc3339() },
+            ]
+        }]
+    });
+    if let Err(e) = client.post(&tm.webhook_url).json(&payload).send().await {
+        tracing::warn!("Teams namespace notification failed for ns '{}': {e}", namespace);
     }
 }

--- a/src/process/instance.rs
+++ b/src/process/instance.rs
@@ -3,10 +3,12 @@
 use crate::config::ecosystem::AppConfig;
 use crate::logging::writer::LogWriter;
 use crate::models::cron_run::CronRun;
+use crate::models::log_stats::LogStatsState;
 use crate::models::process_info::{HealthCheckStatus, ProcessInfo};
 use crate::models::process_status::ProcessStatus;
 use chrono::{DateTime, Utc};
-use tokio::sync::broadcast;
+use std::sync::Arc;
+use tokio::sync::{broadcast, Mutex};
 use uuid::Uuid;
 
 /// A single log line emitted by a child process
@@ -51,6 +53,8 @@ pub struct ManagedProcess {
     pub health_status: Option<HealthCheckStatus>,
     /// Handle to the running health check task — aborted on process stop
     pub health_check_handle: Option<tokio::task::JoinHandle<()>>,
+    // @group BusinessLogic > LogStats : Rolling 5-minute log volume buckets (stdout + stderr counts)
+    pub log_stats: Arc<Mutex<LogStatsState>>,
 }
 
 impl ManagedProcess {
@@ -79,6 +83,7 @@ impl ManagedProcess {
             memory_bytes: None,
             health_status: None,
             health_check_handle: None,
+            log_stats: Arc::new(Mutex::new(LogStatsState::new())),
         }
     }
 

--- a/src/process/manager.rs
+++ b/src/process/manager.rs
@@ -4,6 +4,7 @@ use crate::config::ecosystem::AppConfig;
 use crate::config::notification_store::NotificationsStore;
 use crate::logging::writer::LogWriter;
 use crate::models::cron_run::{CronRun, MAX_CRON_HISTORY};
+use crate::models::metric_sample::MetricSample;
 use crate::models::process_info::ProcessInfo;
 use crate::models::process_status::ProcessStatus;
 use crate::notifications::sender::{fire_event, ProcessEvent};
@@ -15,12 +16,17 @@ use crate::process::watcher::FileWatcher;
 use anyhow::{anyhow, Result};
 use chrono::Utc;
 use dashmap::DashMap;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
 use tokio::sync::mpsc;
 use tokio::sync::{broadcast, Mutex, RwLock};
 use uuid::Uuid;
+
+// @group Constants : Maximum number of metric samples retained per process (288 × 30 s ≈ 2.4 h)
+const MAX_METRIC_SAMPLES: usize = 288;
+// @group Constants : Collect one metric sample every N metric-loop ticks (tick = 3 s → 10 × 3 s = 30 s)
+const METRIC_SAMPLE_INTERVAL_TICKS: u32 = 10;
 
 pub type ProcessRegistry = DashMap<Uuid, Arc<RwLock<ManagedProcess>>>;
 
@@ -33,6 +39,11 @@ pub struct ProcessManager {
     cron_schedulers: Arc<Mutex<HashMap<Uuid, CronScheduler>>>,
     /// Shared notification store for firing alerts on process events
     notifications: Arc<RwLock<NotificationsStore>>,
+    /// Suppress per-process Telegram notifications during bulk namespace ops.
+    /// Value = remaining events to suppress (2 for restart = stop+start, 1 otherwise).
+    pub bulk_suppress: Arc<DashMap<Uuid, u32>>,
+    // @group BusinessLogic > Metrics : Rolling per-process metric history (CPU + mem samples)
+    pub metrics_history: Arc<DashMap<Uuid, Mutex<VecDeque<MetricSample>>>>,
 }
 
 impl ProcessManager {
@@ -63,10 +74,21 @@ impl ProcessManager {
         });
 
         let reg_metrics = Arc::clone(&registry);
+        let metrics_history: Arc<DashMap<Uuid, Mutex<VecDeque<MetricSample>>>> =
+            Arc::new(DashMap::new());
+        let hist_metrics = Arc::clone(&metrics_history);
 
         // @group BusinessLogic > Metrics : Background task that polls CPU and memory per process
         tokio::spawn(async move {
-            Self::metrics_loop(reg_metrics).await;
+            Self::metrics_loop(reg_metrics, hist_metrics).await;
+        });
+
+        let reg_alert = Arc::clone(&registry);
+        let notif_alert = Arc::clone(&notifications);
+
+        // @group BusinessLogic > LogAlerts : Background task that checks stderr spikes every 5 minutes
+        tokio::spawn(async move {
+            Self::log_alert_loop(reg_alert, notif_alert).await;
         });
 
         Self {
@@ -75,7 +97,23 @@ impl ProcessManager {
             cron_trigger_tx,
             cron_schedulers,
             notifications,
+            bulk_suppress: Arc::new(DashMap::new()),
+            metrics_history,
         }
+    }
+
+    // @group Utilities > BulkSuppress : Decrement suppress counter; return true if the event should be suppressed
+    fn suppress_consume(suppress: &DashMap<Uuid, u32>, id: &Uuid) -> bool {
+        if let Some(mut entry) = suppress.get_mut(id) {
+            if *entry > 1 {
+                *entry -= 1;
+            } else {
+                drop(entry);
+                suppress.remove(id);
+            }
+            return true;
+        }
+        false
     }
 
     // @group BusinessLogic > Lifecycle : Start a new process from config
@@ -232,11 +270,14 @@ impl ProcessManager {
 
         let info_for_notif = proc.to_info();
         let notif = Arc::clone(&self.notifications);
+        let suppress = Arc::clone(&self.bulk_suppress);
         let info_clone = info_for_notif.clone();
         tokio::spawn(async move {
-            let store = notif.read().await;
-            fire_event(&store, &info_clone, ProcessEvent::Stopped).await;
-            crate::telegram::commands::fire_telegram_notification(&info_clone, ProcessEvent::Stopped).await;
+            if !Self::suppress_consume(&suppress, &info_clone.id) {
+                let store = notif.read().await;
+                fire_event(&store, &info_clone, ProcessEvent::Stopped).await;
+                crate::telegram::commands::fire_telegram_notification(&info_clone, ProcessEvent::Stopped).await;
+            }
         });
 
         Ok(info_for_notif)
@@ -314,6 +355,92 @@ impl ProcessManager {
         Ok(guard.to_info())
     }
 
+    // @group BusinessLogic > Namespace : Start all stopped/crashed processes in a namespace (bulk — one Telegram notification)
+    pub async fn start_namespace(&self, namespace: &str) -> Vec<ProcessInfo> {
+        let ids: Vec<Uuid> = {
+            let mut result = vec![];
+            for entry in self.registry.iter() {
+                let proc = entry.value().read().await;
+                if proc.config.namespace == namespace
+                    && matches!(proc.status, ProcessStatus::Stopped | ProcessStatus::Crashed | ProcessStatus::Errored)
+                {
+                    result.push(proc.id);
+                }
+            }
+            result
+        };
+        for &id in &ids {
+            self.bulk_suppress.insert(id, 1);
+        }
+        let mut infos = vec![];
+        for id in ids {
+            if self.do_spawn(id).await.is_ok() {
+                if let Ok(info) = self.get(id).await {
+                    infos.push(info);
+                }
+            }
+        }
+        infos
+    }
+
+    // @group BusinessLogic > Namespace : Stop all running processes in a namespace (bulk — one Telegram notification)
+    pub async fn stop_namespace(&self, namespace: &str) -> Vec<ProcessInfo> {
+        let ids: Vec<Uuid> = {
+            let mut result = vec![];
+            for entry in self.registry.iter() {
+                let proc = entry.value().read().await;
+                if proc.config.namespace == namespace
+                    && matches!(proc.status, ProcessStatus::Running | ProcessStatus::Watching | ProcessStatus::Sleeping)
+                {
+                    result.push(proc.id);
+                }
+            }
+            result
+        };
+        for &id in &ids {
+            self.bulk_suppress.insert(id, 1);
+        }
+        let mut infos = vec![];
+        for id in ids {
+            if let Ok(info) = self.stop(id).await {
+                infos.push(info);
+            }
+        }
+        infos
+    }
+
+    // @group BusinessLogic > Namespace : Restart all processes in a namespace (bulk — one Telegram notification)
+    pub async fn restart_namespace(&self, namespace: &str) -> Vec<ProcessInfo> {
+        // Collect ids paired with whether the process is currently active.
+        // Active processes will emit stop + start (2 events); inactive ones only start (1 event).
+        // Setting the wrong count leaves a stale suppress entry that silently eats a future
+        // individual notification (e.g. the next manual stop).
+        let ids: Vec<(Uuid, bool)> = {
+            let mut result = vec![];
+            for entry in self.registry.iter() {
+                let proc = entry.value().read().await;
+                if proc.config.namespace == namespace {
+                    let is_active = matches!(
+                        proc.status,
+                        ProcessStatus::Running | ProcessStatus::Watching | ProcessStatus::Sleeping
+                    );
+                    result.push((proc.id, is_active));
+                }
+            }
+            result
+        };
+        for &(id, is_active) in &ids {
+            self.bulk_suppress.insert(id, if is_active { 2 } else { 1 });
+        }
+        let mut infos = vec![];
+        for (id, _) in ids {
+            if let Ok(info) = self.restart(id).await {
+                infos.push(info);
+            }
+        }
+        infos
+    }
+
     // @group BusinessLogic > Lifecycle : Reset restart counter
     pub async fn reset(&self, id: Uuid) -> Result<ProcessInfo> {
         let arc = self.get_arc(id)?;
@@ -331,6 +458,30 @@ impl ProcessManager {
         }
         result.sort_by(|a, b| a.created_at.cmp(&b.created_at));
         result
+    }
+
+    // @group BusinessLogic > LogStats : Return bucketed stdout/stderr log counts for a process
+    pub async fn get_log_stats(&self, id: Uuid) -> Vec<crate::models::log_stats::LogStatsBucket> {
+        match self.registry.get(&id) {
+            Some(arc) => {
+                // Clone the Arc out before dropping the read guard to avoid lifetime issues
+                let stats_arc = {
+                    let proc = arc.read().await;
+                    Arc::clone(&proc.log_stats)
+                };
+                let snapshot = stats_arc.lock().await.snapshot();
+                snapshot
+            }
+            None => Vec::new(),
+        }
+    }
+
+    // @group BusinessLogic > Metrics : Return a snapshot of all recorded samples for a process
+    pub async fn get_metrics_history(&self, id: Uuid) -> Vec<MetricSample> {
+        match self.metrics_history.get(&id) {
+            Some(entry) => entry.lock().await.iter().cloned().collect(),
+            None => Vec::new(),
+        }
     }
 
     // @group BusinessLogic > Query : Get a single process info by id
@@ -367,7 +518,7 @@ impl ProcessManager {
     async fn do_spawn(&self, id: Uuid) -> Result<()> {
         let arc = self.get_arc(id)?;
 
-        let (config, log_tx) = {
+        let (config, log_tx, log_stats) = {
             let mut proc = arc.write().await;
             proc.status = ProcessStatus::Starting;
             proc.started_at = Some(Utc::now());
@@ -382,14 +533,15 @@ impl ProcessManager {
             let writer = LogWriter::new(&log_dir, proc.log_tx.clone())?;
             proc.log_writer = Some(writer);
 
-            (proc.config.clone(), proc.log_tx.clone())
+            (proc.config.clone(), proc.log_tx.clone(), Arc::clone(&proc.log_stats))
         };
 
         // @group BusinessLogic > Hooks : Run pre_start hook before spawning
         if let Some(cmd) = &config.pre_start {
-            crate::process::hooks::run_hook(cmd, config.cwd.as_deref(), &config.env)
-                .await
-                .map_err(|e| anyhow::anyhow!("pre_start hook failed: {e}"))?;
+            if let Err(e) = crate::process::hooks::run_hook(cmd, config.cwd.as_deref(), &config.env).await {
+                arc.write().await.status = ProcessStatus::Errored;
+                return Err(anyhow::anyhow!("pre_start hook failed: {e}"));
+            }
         }
 
         // @group BusinessLogic > EnvFile : Merge .env file vars with explicit env (explicit wins)
@@ -401,7 +553,7 @@ impl ProcessManager {
 
         let (exit_tx, exit_rx) = mpsc::channel::<crate::process::runner::RunResult>(1);
 
-        let child = spawn_process(
+        let child = match spawn_process(
             id,
             &config.script,
             &config.args,
@@ -409,8 +561,15 @@ impl ProcessManager {
             &merged_env,
             log_tx,
             exit_tx.clone(),
+            log_stats,
         )
-        .await?;
+        .await {
+            Ok(c) => c,
+            Err(e) => {
+                arc.write().await.status = ProcessStatus::Errored;
+                return Err(e);
+            }
+        };
 
         let pid = child.id();
 
@@ -429,11 +588,14 @@ impl ProcessManager {
 
         // Fire Started notification (non-blocking)
         let notif = Arc::clone(&self.notifications);
+        let suppress = Arc::clone(&self.bulk_suppress);
         let info_for_tg = info_for_notif.clone();
         tokio::spawn(async move {
-            let store = notif.read().await;
-            fire_event(&store, &info_for_notif, ProcessEvent::Started).await;
-            crate::telegram::commands::fire_telegram_notification(&info_for_tg, ProcessEvent::Started).await;
+            if !Self::suppress_consume(&suppress, &info_for_tg.id) {
+                let store = notif.read().await;
+                fire_event(&store, &info_for_notif, ProcessEvent::Started).await;
+                crate::telegram::commands::fire_telegram_notification(&info_for_tg, ProcessEvent::Started).await;
+            }
         });
 
         // @group BusinessLogic > Hooks : Run post_start hook after process is running (non-blocking)
@@ -550,14 +712,14 @@ impl ProcessManager {
                                 proc.started_at = Some(Utc::now());
                             }
 
-                            let (config, log_tx) = {
+                            let (config, log_tx, log_stats) = {
                                 let mut proc = arc.write().await;
                                 let log_dir = crate::config::paths::process_log_dir(&proc.config.name);
                                 let _ = std::fs::create_dir_all(&log_dir);
                                 if let Ok(writer) = LogWriter::new(&log_dir, proc.log_tx.clone()) {
                                     proc.log_writer = Some(writer);
                                 }
-                                (proc.config.clone(), proc.log_tx.clone())
+                                (proc.config.clone(), proc.log_tx.clone(), Arc::clone(&proc.log_stats))
                             };
 
                             let (exit_tx, exit_rx) = mpsc::channel::<crate::process::runner::RunResult>(1);
@@ -577,6 +739,7 @@ impl ProcessManager {
                                 &merged_env,
                                 log_tx,
                                 exit_tx.clone(),
+                                log_stats,
                             ).await {
                                 Ok(child) => {
                                     let pid = child.id();
@@ -721,12 +884,12 @@ impl ProcessManager {
                     let log_dir = crate::config::paths::process_log_dir(&config.name);
                     let _ = std::fs::create_dir_all(&log_dir);
 
-                    let log_tx = {
+                    let (log_tx, log_stats) = {
                         let mut proc = arc.write().await;
                         if let Ok(writer) = LogWriter::new(&log_dir, proc.log_tx.clone()) {
                             proc.log_writer = Some(writer);
                         }
-                        proc.log_tx.clone()
+                        (proc.log_tx.clone(), Arc::clone(&proc.log_stats))
                     };
 
                     let (exit_tx, exit_rx) = mpsc::channel::<crate::process::runner::RunResult>(1);
@@ -804,6 +967,7 @@ impl ProcessManager {
                         &merged_env,
                         log_tx,
                         exit_tx.clone(),
+                        log_stats,
                     ).await {
                         Ok(child) => {
                             let pid = child.id();
@@ -868,10 +1032,16 @@ impl ProcessManager {
     }
 
     // @group BusinessLogic > Metrics : Periodically collects CPU and memory for each running process
-    async fn metrics_loop(registry: Arc<ProcessRegistry>) {
+    async fn metrics_loop(
+        registry: Arc<ProcessRegistry>,
+        hist: Arc<DashMap<Uuid, Mutex<VecDeque<MetricSample>>>>,
+    ) {
         let mut sys = System::new();
+        let mut tick: u32 = 0;
+
         loop {
             tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+            tick = tick.wrapping_add(1);
 
             // Collect process IDs that currently have a PID (i.e. are running)
             let pid_map: Vec<(Uuid, Pid)> = {
@@ -897,18 +1067,106 @@ impl ProcessManager {
                 ProcessRefreshKind::new().with_cpu().with_memory(),
             );
 
+            // @group BusinessLogic > Metrics : Decide whether this tick records a history sample
+            let record_sample = tick % METRIC_SAMPLE_INTERVAL_TICKS == 0;
+            let now = Utc::now();
+
             // Write new metrics back into each process entry
             for (id, sysinfo_pid) in &pid_map {
                 if let Some(arc) = registry.get(id) {
                     let mut proc = arc.write().await;
                     if let Some(sp) = sys.process(*sysinfo_pid) {
-                        proc.cpu_percent = Some(sp.cpu_usage());
-                        proc.memory_bytes = Some(sp.memory());
+                        let cpu = sp.cpu_usage();
+                        let mem = sp.memory();
+                        proc.cpu_percent = Some(cpu);
+                        proc.memory_bytes = Some(mem);
+
+                        // @group BusinessLogic > Metrics : Push sample into the per-process ring buffer
+                        if record_sample {
+                            let entry = hist.entry(*id).or_insert_with(|| {
+                                Mutex::new(VecDeque::with_capacity(MAX_METRIC_SAMPLES + 1))
+                            });
+                            let mut buf = entry.lock().await;
+                            buf.push_back(MetricSample {
+                                timestamp: now,
+                                cpu_percent: cpu,
+                                memory_bytes: mem,
+                            });
+                            if buf.len() > MAX_METRIC_SAMPLES {
+                                buf.pop_front();
+                            }
+                        }
                     } else {
                         proc.cpu_percent = None;
                         proc.memory_bytes = None;
                     }
                 }
+            }
+        }
+    }
+
+    // @group BusinessLogic > LogAlerts : Wake every 5 min, check last closed bucket per process, fire alerts
+    async fn log_alert_loop(
+        registry: Arc<ProcessRegistry>,
+        notifications: Arc<RwLock<NotificationsStore>>,
+    ) {
+        // Per-process cooldown tracker — stores the last time an alert was fired
+        let mut last_alerted: HashMap<Uuid, chrono::DateTime<Utc>> = HashMap::new();
+
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_secs(300)).await;
+
+            // Read config fresh from disk each cycle so changes take effect immediately
+            let cfg = crate::config::log_alert_config::load();
+            if !cfg.enabled {
+                continue;
+            }
+
+            let threshold = cfg.stderr_threshold;
+            let cooldown_secs = cfg.cooldown_mins as i64 * 60;
+            let now = Utc::now();
+
+            for entry in registry.iter() {
+                let id = *entry.key();
+
+                // Check cooldown before taking any locks
+                if let Some(&last) = last_alerted.get(&id) {
+                    if (now - last).num_seconds() < cooldown_secs {
+                        continue;
+                    }
+                }
+
+                // Clone the Arc<Mutex<LogStatsState>> without holding the RwLock guard
+                let (stats_arc, proc_info) = {
+                    let proc = entry.value().read().await;
+                    (Arc::clone(&proc.log_stats), proc.to_info())
+                };
+
+                let stderr_count = {
+                    let stats = stats_arc.lock().await;
+                    // Use the most recently completed bucket
+                    stats.history.back().map(|b| b.stderr_count).unwrap_or(0)
+                };
+
+                if stderr_count < threshold {
+                    continue;
+                }
+
+                // Threshold exceeded — record cooldown and fire
+                last_alerted.insert(id, now);
+
+                let notif = Arc::clone(&notifications);
+                let name = proc_info.name.clone();
+
+                tokio::spawn(async move {
+                    let store = notif.read().await;
+                    crate::notifications::sender::fire_log_alert(
+                        &store, &proc_info, stderr_count, threshold,
+                    ).await;
+                    crate::telegram::commands::fire_log_alert_telegram(
+                        &name, stderr_count, threshold,
+                    ).await;
+                });
             }
         }
     }

--- a/src/process/runner.rs
+++ b/src/process/runner.rs
@@ -1,15 +1,18 @@
 // @group BusinessLogic : Spawn child process and pipe stdout/stderr to log infrastructure
 
+use crate::models::log_stats::LogStatsState;
 use crate::process::instance::{LogLine, LogStream};
 use anyhow::{Context, Result};
 use chrono::Utc;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::Stdio;
+use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::broadcast;
 use tokio::sync::mpsc;
+use tokio::sync::Mutex;
 use uuid::Uuid;
 
 // @group BusinessLogic > Windows : Process creation flags
@@ -36,6 +39,7 @@ pub async fn spawn_process(
     env_vars: &HashMap<String, String>,
     log_tx: broadcast::Sender<LogLine>,
     exit_tx: mpsc::Sender<RunResult>,
+    log_stats: Arc<Mutex<LogStatsState>>,
 ) -> Result<Child> {
     // @group BusinessLogic > Windows : npm/node/python etc. are .cmd batch scripts on Windows.
     // Wrap with cmd.exe /C so the shell resolves them correctly.
@@ -85,8 +89,9 @@ pub async fn spawn_process(
     let stdout = child.stdout.take().expect("stdout was piped");
     let stderr = child.stderr.take().expect("stderr was piped");
 
-    // @group BusinessLogic > Logging : Stream stdout to broadcast + disk
+    // @group BusinessLogic > Logging : Stream stdout to broadcast + disk + log stats counter
     let stdout_tx = log_tx.clone();
+    let stats_out = Arc::clone(&log_stats);
     tokio::spawn(async move {
         let mut reader = BufReader::new(stdout).lines();
         while let Ok(Some(line)) = reader.next_line().await {
@@ -97,11 +102,13 @@ pub async fn spawn_process(
                 content: line,
             };
             let _ = stdout_tx.send(entry);
+            stats_out.lock().await.record(true);
         }
     });
 
-    // @group BusinessLogic > Logging : Stream stderr to broadcast + disk
+    // @group BusinessLogic > Logging : Stream stderr to broadcast + disk + log stats counter
     let stderr_tx = log_tx.clone();
+    let stats_err = Arc::clone(&log_stats);
     tokio::spawn(async move {
         let mut reader = BufReader::new(stderr).lines();
         while let Ok(Some(line)) = reader.next_line().await {
@@ -112,6 +119,7 @@ pub async fn spawn_process(
                 content: line,
             };
             let _ = stderr_tx.send(entry);
+            stats_err.lock().await.record(false);
         }
     });
 

--- a/src/telegram/bot.rs
+++ b/src/telegram/bot.rs
@@ -38,6 +38,35 @@ struct From {
     id: i64,
 }
 
+// @group BusinessLogic : Register bot commands with Telegram for autocomplete (setMyCommands)
+async fn register_commands(client: &reqwest::Client, token: &str) {
+    let url = format!("{TG_API}/bot{token}/setMyCommands");
+    let commands = serde_json::json!({
+        "commands": [
+            { "command": "list",      "description": "List all processes and their status" },
+            { "command": "status",    "description": "Get status of a process: /status <name>" },
+            { "command": "start",   "description": "Start process or namespace: /start <name> | /start ns <ns>" },
+            { "command": "stop",    "description": "Stop process or namespace: /stop <name> | /stop ns <ns>" },
+            { "command": "restart", "description": "Restart process or namespace: /restart <name> | /restart ns <ns>" },
+            { "command": "logs",    "description": "Get recent logs: /logs <name> [lines]" },
+            { "command": "ping",      "description": "Check if the daemon is responsive" },
+            { "command": "help",      "description": "Show available commands" }
+        ]
+    });
+
+    match client.post(&url).json(&commands).send().await {
+        Ok(r) if r.status().is_success() => {
+            tracing::info!("telegram: commands registered for autocomplete");
+        }
+        Ok(r) => {
+            tracing::warn!("telegram: setMyCommands returned {}", r.status());
+        }
+        Err(e) => {
+            tracing::warn!("telegram: setMyCommands failed: {e}");
+        }
+    }
+}
+
 // @group BusinessLogic : Entry point — run the polling loop as a background task
 pub async fn run(state: Arc<DaemonState>) {
     let client = reqwest::Client::builder()
@@ -46,6 +75,9 @@ pub async fn run(state: Arc<DaemonState>) {
         .expect("failed to build reqwest client for telegram bot");
 
     let mut offset: i64 = 0;
+    // @group BusinessLogic > State : Track which token we last registered commands for,
+    // so we re-register automatically if the token changes at runtime.
+    let mut registered_for_token: Option<String> = None;
 
     loop {
         // @group BusinessLogic > Config : Re-read config each cycle so hot changes take effect
@@ -60,6 +92,12 @@ pub async fn run(state: Arc<DaemonState>) {
         }
 
         let token = token.unwrap();
+
+        // @group BusinessLogic > Commands : Register autocomplete commands once per token
+        if registered_for_token.as_deref() != Some(&token) {
+            register_commands(&client, &token).await;
+            registered_for_token = Some(token.clone());
+        }
 
         // @group BusinessLogic > Polling : Fetch updates via long poll (timeout=30s)
         let url = format!(
@@ -166,23 +204,32 @@ async fn dispatch_command(
             }
         }
         "/start" => {
-            // /start with an argument means "start process", not the bot greeting
-            commands::cmd_start(state, token, chat_id, parts[1]).await
-        }
-        "/stop" => {
-            if parts.len() < 2 {
-                commands::send_message(token, chat_id, "Usage: /stop &lt;name&gt;").await
-            } else {
-                commands::cmd_stop(state, token, chat_id, parts[1]).await
+            // /start with an argument — "ns <namespace>" targets a namespace, otherwise a process name
+            match parts.get(1) {
+                Some(&"ns") => match parts.get(2) {
+                    Some(ns) => commands::cmd_start_namespace(state, token, chat_id, ns).await,
+                    None => commands::send_message(token, chat_id, "Usage: /start ns &lt;namespace&gt;").await,
+                },
+                Some(name) => commands::cmd_start(state, token, chat_id, name).await,
+                None => commands::cmd_help(token, chat_id).await,
             }
         }
-        "/restart" => {
-            if parts.len() < 2 {
-                commands::send_message(token, chat_id, "Usage: /restart &lt;name&gt;").await
-            } else {
-                commands::cmd_restart(state, token, chat_id, parts[1]).await
-            }
-        }
+        "/stop" => match parts.get(1) {
+            Some(&"ns") => match parts.get(2) {
+                Some(ns) => commands::cmd_stop_namespace(state, token, chat_id, ns).await,
+                None => commands::send_message(token, chat_id, "Usage: /stop ns &lt;namespace&gt;").await,
+            },
+            Some(name) => commands::cmd_stop(state, token, chat_id, name).await,
+            None => commands::send_message(token, chat_id, "Usage: /stop &lt;name&gt; | /stop ns &lt;namespace&gt;").await,
+        },
+        "/restart" => match parts.get(1) {
+            Some(&"ns") => match parts.get(2) {
+                Some(ns) => commands::cmd_restart_namespace(state, token, chat_id, ns).await,
+                None => commands::send_message(token, chat_id, "Usage: /restart ns &lt;namespace&gt;").await,
+            },
+            Some(name) => commands::cmd_restart(state, token, chat_id, name).await,
+            None => commands::send_message(token, chat_id, "Usage: /restart &lt;name&gt; | /restart ns &lt;namespace&gt;").await,
+        },
         "/logs" => {
             if parts.len() < 2 {
                 commands::send_message(token, chat_id, "Usage: /logs &lt;name&gt; [lines]").await

--- a/src/telegram/commands.rs
+++ b/src/telegram/commands.rs
@@ -4,7 +4,7 @@ use crate::daemon::state::DaemonState;
 use crate::logging::reader::read_merged_logs;
 use crate::models::process_info::ProcessInfo;
 use crate::models::process_status::ProcessStatus;
-use crate::notifications::sender::ProcessEvent;
+use crate::notifications::sender::{fire_namespace_event, ProcessEvent};
 use anyhow::Result;
 use std::sync::Arc;
 
@@ -36,35 +36,51 @@ pub async fn cmd_help(bot_token: &str, chat_id: i64) -> Result<()> {
     let text = concat!(
         "🤖 <b>alter-pm2 Bot Commands</b>\n\n",
         "/list — list all processes\n",
-        "/status &lt;name&gt; — detailed process info\n",
-        "/start &lt;name&gt; — start a stopped process\n",
-        "/stop &lt;name&gt; — stop a running process\n",
-        "/restart &lt;name&gt; — restart a process\n",
-        "/logs &lt;name&gt; [lines] — tail logs (default: 20)\n",
+        "/status &lt;name&gt; — detailed info\n",
+        "/logs &lt;name&gt; [lines] — tail logs (default 20)\n\n",
+        "<b>/start &lt;name&gt;</b> — start a process\n",
+        "<b>/start ns &lt;ns&gt;</b> — start all in namespace\n\n",
+        "<b>/stop &lt;name&gt;</b> — stop a process\n",
+        "<b>/stop ns &lt;ns&gt;</b> — stop all in namespace\n\n",
+        "<b>/restart &lt;name&gt;</b> — restart a process\n",
+        "<b>/restart ns &lt;ns&gt;</b> — restart all in namespace\n\n",
         "/ping — check if daemon is alive\n",
         "/help — show this message"
     );
     send_message(bot_token, chat_id, text).await
 }
 
-// @group BusinessLogic > Commands : /list — show all processes with status
+// @group BusinessLogic > Commands : /list — show all processes grouped by namespace
 pub async fn cmd_list(state: &Arc<DaemonState>, bot_token: &str, chat_id: i64) -> Result<()> {
-    let processes = state.manager.list().await;
+    let mut processes = state.manager.list().await;
 
     if processes.is_empty() {
         return send_message(bot_token, chat_id, "No processes registered.").await;
     }
 
-    let mut lines = vec!["<b>Processes:</b>".to_string()];
+    // Sort by namespace then name for stable output
+    processes.sort_by(|a, b| a.namespace.cmp(&b.namespace).then(a.name.cmp(&b.name)));
+
+    let mut lines = vec![];
+    let mut current_ns: Option<&str> = None;
+
     for p in &processes {
+        let ns = p.namespace.as_str();
+        if current_ns != Some(ns) {
+            if current_ns.is_some() {
+                lines.push(String::new()); // blank line between namespaces
+            }
+            lines.push(format!("📁 <b>{}</b>", escape_html(ns)));
+            current_ns = Some(ns);
+        }
         let emoji = status_emoji(&p.status);
         let uptime = p
             .uptime_secs
             .map(|s| format_uptime(s))
             .unwrap_or_else(|| "—".to_string());
         lines.push(format!(
-            "{emoji} <b>{}</b> · {} · ↺{} · ⏱{}",
-            p.name,
+            "  {emoji} <b>{}</b> · {} · ↺{} · ⏱{}",
+            escape_html(&p.name),
             p.status,
             p.restart_count,
             uptime
@@ -233,6 +249,148 @@ pub async fn cmd_restart(
     }
 }
 
+// @group BusinessLogic > Commands : /startns <namespace> — start all stopped/crashed processes in a namespace
+pub async fn cmd_start_namespace(
+    state: &Arc<DaemonState>,
+    bot_token: &str,
+    chat_id: i64,
+    namespace: &str,
+) -> Result<()> {
+    let affected = state.manager.start_namespace(namespace).await;
+    if affected.is_empty() {
+        return send_message(
+            bot_token,
+            chat_id,
+            &format!(
+                "⚠️ No stopped/crashed processes found in namespace <b>{}</b>",
+                escape_html(namespace)
+            ),
+        )
+        .await;
+    }
+
+    // Fire webhook/Slack/Teams namespace summary (Telegram is handled by send_message below)
+    {
+        let store = state.notifications.read().await;
+        fire_namespace_event(&store, namespace, &affected, ProcessEvent::Started).await;
+    }
+
+    // Wait for processes to settle, then re-query for accurate status
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    let current = state.manager.list().await;
+    let names: Vec<String> = affected
+        .iter()
+        .map(|p| {
+            let status = current.iter().find(|c| c.id == p.id).map(|c| format!(" · {}", c.status)).unwrap_or_default();
+            format!("  • <b>{}</b>{}", escape_html(&p.name), status)
+        })
+        .collect();
+
+    send_message(
+        bot_token,
+        chat_id,
+        &format!(
+            "✅ Started {} process{} in namespace <b>{}</b>:\n{}",
+            affected.len(),
+            if affected.len() == 1 { "" } else { "es" },
+            escape_html(namespace),
+            names.join("\n")
+        ),
+    )
+    .await
+}
+
+// @group BusinessLogic > Commands : /stopns <namespace> — stop all running processes in a namespace
+pub async fn cmd_stop_namespace(
+    state: &Arc<DaemonState>,
+    bot_token: &str,
+    chat_id: i64,
+    namespace: &str,
+) -> Result<()> {
+    let affected = state.manager.stop_namespace(namespace).await;
+    if affected.is_empty() {
+        send_message(
+            bot_token,
+            chat_id,
+            &format!(
+                "⚠️ No running processes found in namespace <b>{}</b>",
+                escape_html(namespace)
+            ),
+        )
+        .await
+    } else {
+        // Fire webhook/Slack/Teams namespace summary (Telegram is handled by send_message below)
+        {
+            let store = state.notifications.read().await;
+            fire_namespace_event(&store, namespace, &affected, ProcessEvent::Stopped).await;
+        }
+        let names: Vec<String> = affected.iter().map(|p| format!("  • <b>{}</b>", escape_html(&p.name))).collect();
+        send_message(
+            bot_token,
+            chat_id,
+            &format!(
+                "🛑 Stopped {} process{} in namespace <b>{}</b>:\n{}",
+                affected.len(),
+                if affected.len() == 1 { "" } else { "es" },
+                escape_html(namespace),
+                names.join("\n")
+            ),
+        )
+        .await
+    }
+}
+
+// @group BusinessLogic > Commands : /restartns <namespace> — restart all processes in a namespace
+pub async fn cmd_restart_namespace(
+    state: &Arc<DaemonState>,
+    bot_token: &str,
+    chat_id: i64,
+    namespace: &str,
+) -> Result<()> {
+    let affected = state.manager.restart_namespace(namespace).await;
+    if affected.is_empty() {
+        return send_message(
+            bot_token,
+            chat_id,
+            &format!(
+                "⚠️ No processes found in namespace <b>{}</b>",
+                escape_html(namespace)
+            ),
+        )
+        .await;
+    }
+
+    // Fire webhook/Slack/Teams namespace summary (Telegram is handled by send_message below)
+    {
+        let store = state.notifications.read().await;
+        fire_namespace_event(&store, namespace, &affected, ProcessEvent::Restarted).await;
+    }
+
+    // Wait for processes to settle after stop+start, then re-query for accurate status
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    let current = state.manager.list().await;
+    let names: Vec<String> = affected
+        .iter()
+        .map(|p| {
+            let status = current.iter().find(|c| c.id == p.id).map(|c| format!(" · {}", c.status)).unwrap_or_default();
+            format!("  • <b>{}</b>{}", escape_html(&p.name), status)
+        })
+        .collect();
+
+    send_message(
+        bot_token,
+        chat_id,
+        &format!(
+            "🔄 Restarted {} process{} in namespace <b>{}</b>:\n{}",
+            affected.len(),
+            if affected.len() == 1 { "" } else { "es" },
+            escape_html(namespace),
+            names.join("\n")
+        ),
+    )
+    .await
+}
+
 // @group BusinessLogic > Commands : /logs <name> [N] — tail last N log lines
 pub async fn cmd_logs(
     state: &Arc<DaemonState>,
@@ -340,6 +498,70 @@ pub fn escape_html(s: &str) -> String {
         .replace('>', "&gt;")
 }
 
+// @group BusinessLogic > Notifications : Fire a single Telegram notification for a bulk namespace operation.
+// Sends one message listing all affected processes instead of one per process.
+pub async fn fire_telegram_namespace_notification(
+    namespace: &str,
+    event: ProcessEvent,
+    processes: &[ProcessInfo],
+) {
+    if processes.is_empty() {
+        return;
+    }
+
+    let cfg = crate::config::telegram_config::load();
+    if !cfg.enabled {
+        return;
+    }
+    let token = match cfg.bot_token {
+        Some(ref t) => t.clone(),
+        None => return,
+    };
+
+    let should_send = match event {
+        ProcessEvent::Crashed | ProcessEvent::CronFailed => cfg.notify_on_crash,
+        ProcessEvent::Started | ProcessEvent::CronRun => cfg.notify_on_start,
+        ProcessEvent::Stopped => cfg.notify_on_stop,
+        ProcessEvent::Restarted => cfg.notify_on_restart,
+    };
+
+    if !should_send || cfg.allowed_chat_ids.is_empty() {
+        return;
+    }
+
+    let (emoji, verb) = match event {
+        ProcessEvent::Started   => ("🟢", "started"),
+        ProcessEvent::Stopped   => ("⚪", "stopped"),
+        ProcessEvent::Restarted => ("🔄", "restarted"),
+        ProcessEvent::Crashed   => ("💥", "crashed"),
+        ProcessEvent::CronRun   => ("⏰", "cron started"),
+        ProcessEvent::CronFailed => ("❌", "cron failed"),
+    };
+
+    let ns = escape_html(namespace);
+    let count = processes.len();
+    let header = format!(
+        "{emoji} <b>Namespace: {ns}</b> — {count} process{} {verb}",
+        if count == 1 { "" } else { "es" }
+    );
+
+    let items: Vec<String> = processes
+        .iter()
+        .map(|p| {
+            let pid_str = p.pid.map(|pid| format!(" · PID {pid}")).unwrap_or_default();
+            format!("  • <b>{}</b>{}", escape_html(&p.name), pid_str)
+        })
+        .collect();
+
+    let msg = format!("{}\n{}", header, items.join("\n"));
+
+    for &chat_id in &cfg.allowed_chat_ids {
+        if let Err(e) = send_message(&token, chat_id, &msg).await {
+            tracing::warn!("telegram: failed to send namespace notification to {chat_id}: {e}");
+        }
+    }
+}
+
 // @group BusinessLogic > Notifications : Fire a Telegram push notification for a process event.
 // Reads config from disk on each call — cheap for infrequent events.
 pub async fn fire_telegram_notification(proc: &ProcessInfo, event: ProcessEvent) {
@@ -392,5 +614,38 @@ pub async fn fire_telegram_notification(proc: &ProcessInfo, event: ProcessEvent)
         if let Err(e) = send_message(&token, chat_id, &msg).await {
             tracing::warn!("telegram: failed to send notification to {chat_id}: {e}");
         }
+    }
+}
+
+// @group BusinessLogic > LogAlertTelegram : Send a log-spike alert to all allowed Telegram chats
+pub async fn fire_log_alert_telegram(process_name: &str, stderr_count: u64, threshold: u64) {
+    let cfg = crate::config::telegram_config::load();
+    if !cfg.enabled || cfg.allowed_chat_ids.is_empty() {
+        return;
+    }
+    let token = match cfg.bot_token {
+        Some(ref t) => t.clone(),
+        None => return,
+    };
+
+    let name = escape_html(process_name);
+    let msg = format!(
+        "⚠️ <b>{name}</b> — log spike detected\n\
+         Stderr lines: <b>{stderr_count}</b> in the last 5 min\n\
+         Threshold: {threshold}"
+    );
+
+    let client = reqwest::Client::new();
+    for chat_id in &cfg.allowed_chat_ids {
+        let url = format!("https://api.telegram.org/bot{token}/sendMessage");
+        let _ = client
+            .post(&url)
+            .json(&serde_json::json!({
+                "chat_id": chat_id,
+                "text": msg,
+                "parse_mode": "HTML",
+            }))
+            .send()
+            .await;
     }
 }

--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react'
 import LoginPage from '@/pages/LoginPage'
 import { isAuthenticated, setSessionToken } from '@/lib/auth'
-import { BrowserRouter, Link, Route, Routes, useLocation, useNavigate } from 'react-router-dom'
+import { BrowserRouter, Link, Route, Routes, useLocation, useNavigate, useParams } from 'react-router-dom'
 import { LayoutGrid, Plus, Clock, ScrollText, Settings, Bell, Bot, Network, type LucideIcon } from 'lucide-react'
 import { useDaemonHealth } from '@/hooks/useDaemonHealth'
 import { useProcesses } from '@/hooks/useProcesses'
@@ -27,6 +27,13 @@ import LogLibraryPage from '@/pages/LogLibraryPage'
 import NotificationsPage from '@/pages/NotificationsPage'
 import PortFinderPage from '@/pages/PortFinderPage'
 import type { ProcessInfo } from '@/types'
+import type { AppSettings } from '@/lib/settings'
+
+// @group BusinessLogic > NamespaceRoute : Stable module-level wrapper — reads :name param and filters processes
+function NamespaceRoute({ processes, reload, settings }: { processes: ProcessInfo[]; reload: () => void; settings: AppSettings }) {
+  const { name } = useParams<{ name: string }>()
+  return <ProcessesPage processes={processes} reload={reload} settings={settings} namespaceFilter={name} />
+}
 
 // @group BusinessLogic > Layout : Sidebar + content shell
 function Layout({ onLock }: { onLock: () => void }) {
@@ -79,7 +86,7 @@ function Layout({ onLock }: { onLock: () => void }) {
     await api.shutdownDaemon().catch(() => {})
   }
 
-  const isProcessActive = location.pathname === '/processes' || location.pathname.startsWith('/processes/')
+  const isProcessActive = location.pathname === '/processes' || location.pathname.startsWith('/processes/') || location.pathname.startsWith('/namespace/')
   const isCronActive    = location.pathname === '/cron-jobs' || location.pathname === '/cron-jobs/new'
   const isPortsActive   = location.pathname === '/ports'
 
@@ -224,8 +231,9 @@ function Layout({ onLock }: { onLock: () => void }) {
       {/* Main content */}
       <div style={{ flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column' }}>
         <Routes>
-          <Route path="/" element={<AnalyticsPage processes={processes} settings={settings} />} />
+          <Route path="/" element={<AnalyticsPage processes={processes} settings={settings} reload={reload} />} />
           <Route path="/processes" element={<ProcessesPage processes={processes} reload={reload} settings={settings} />} />
+          <Route path="/namespace/:name" element={<NamespaceRoute processes={processes} reload={reload} settings={settings} />} />
           <Route path="/start" element={<StartPage onDone={() => { reload(); navigate('/processes') }} settings={settings} />} />
           <Route path="/edit/:id" element={<EditPage onDone={() => { reload(); navigate('/processes') }} />} />
           <Route path="/processes/:id" element={<ProcessDetailPage reload={reload} settings={settings} />} />

--- a/web-ui/src/lib/api.ts
+++ b/web-ui/src/lib/api.ts
@@ -1,6 +1,6 @@
 // @group APIEndpoints : All fetch calls to the alter daemon REST API
 
-import type { CronRun, DaemonHealth, EnvFileEntry, LogLine, NotificationConfig, NotificationsStore, ProcessInfo, ScriptInfo, StartProcessBody } from '@/types'
+import type { CronRun, DaemonHealth, EnvFileEntry, LogAlertConfig, LogLine, LogStatsBucket, MetricSample, NotificationConfig, NotificationsStore, ProcessInfo, ScriptInfo, StartProcessBody } from '@/types'
 import { clearSessionToken, getSessionToken } from '@/lib/auth'
 
 // @group Types > AI : Chat message and request types (mirrored from Rust models/ai.rs)
@@ -100,6 +100,16 @@ export const api = {
   restartProcess: (id: string): Promise<ProcessInfo> =>
     request(`/processes/${id}/restart`, { method: 'POST' }),
 
+  // @group APIEndpoints > Namespace : Bulk namespace operations — one aggregated notification each
+  startNamespace: (ns: string): Promise<{ namespace: string; started: number; processes: ProcessInfo[] }> =>
+    request(`/processes/namespace/${encodeURIComponent(ns)}/start`, { method: 'POST' }),
+
+  stopNamespace: (ns: string): Promise<{ namespace: string; stopped: number; processes: ProcessInfo[] }> =>
+    request(`/processes/namespace/${encodeURIComponent(ns)}/stop`, { method: 'POST' }),
+
+  restartNamespace: (ns: string): Promise<{ namespace: string; restarted: number; processes: ProcessInfo[] }> =>
+    request(`/processes/namespace/${encodeURIComponent(ns)}/restart`, { method: 'POST' }),
+
   deleteProcess: (id: string): Promise<void> =>
     request(`/processes/${id}`, { method: 'DELETE' }),
 
@@ -111,6 +121,21 @@ export const api = {
 
   openTerminal: (id: string): Promise<void> =>
     request(`/processes/${id}/terminal`, { method: 'POST' }),
+
+  // @group APIEndpoints > Metrics : Rolling CPU + memory history for a process
+  getMetricsHistory: (id: string): Promise<{ samples: MetricSample[] }> =>
+    request(`/processes/${id}/metrics/history`),
+
+  // @group APIEndpoints > LogStats : 5-minute stdout/stderr log count buckets for a process
+  getLogStats: (id: string): Promise<{ buckets: LogStatsBucket[] }> =>
+    request(`/processes/${id}/logs/stats`),
+
+  // @group APIEndpoints > LogAlerts : Get / update the log-spike alert configuration
+  getLogAlerts: (): Promise<LogAlertConfig> =>
+    request('/log-alerts'),
+
+  updateLogAlerts: (config: LogAlertConfig): Promise<LogAlertConfig> =>
+    request('/log-alerts', { method: 'PUT', body: JSON.stringify(config) }),
 
   // @group APIEndpoints > Logs
   getLogs: (id: string, params?: { lines?: number; date?: string }): Promise<{ lines: LogLine[] }> => {

--- a/web-ui/src/pages/AnalyticsPage.tsx
+++ b/web-ui/src/pages/AnalyticsPage.tsx
@@ -1,12 +1,13 @@
 // @group BusinessLogic : Analytics dashboard — process and system metrics
 
-import { useMemo } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import type { CSSProperties, ReactNode } from 'react'
+import type { CSSProperties } from 'react'
 import { useDaemonHealth } from '@/hooks/useDaemonHealth'
 import { formatUptime, statusColor, STATUS_COLORS } from '@/lib/utils'
+import { api } from '@/lib/api'
 import type { AppSettings } from '@/lib/settings'
-import type { ProcessInfo, ProcessStatus } from '@/types'
+import type { LogStatsBucket, ProcessInfo, ProcessStatus } from '@/types'
 
 // @group Types > Analytics : Derived data structures for analytics view
 interface StatusSegment {
@@ -28,12 +29,18 @@ interface NamespaceRow {
 interface Props {
   processes: ProcessInfo[]
   settings: AppSettings
+  reload: () => void
 }
 
 // @group BusinessLogic > AnalyticsPage : Main analytics dashboard page
-export default function AnalyticsPage({ processes, settings }: Props) {
+export default function AnalyticsPage({ processes, settings, reload }: Props) {
   const navigate = useNavigate()
   const health = useDaemonHealth(settings.healthRefreshInterval)
+
+  async function startNamespace(ns: string) {
+    await api.startNamespace(ns).catch(() => {})
+    setTimeout(reload, 300)
+  }
 
   // @group BusinessLogic > Analytics : Compute all derived metrics from processes list
   const stats = useMemo(() => {
@@ -199,34 +206,20 @@ export default function AnalyticsPage({ processes, settings }: Props) {
           </div>
         </div>
 
-        {/* Row 3: Namespace breakdown — only shown when multiple namespaces exist */}
-        {stats.namespaces.length > 1 && (
+        {/* Row 3: Namespace breakdown — shown when any namespace exists */}
+        {stats.namespaces.length > 0 && (
           <div style={cardStyle}>
             <div style={cardHeaderStyle}>Namespace Breakdown</div>
-            <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: 10 }}>
-              <thead>
-                <tr style={{ fontSize: 11, color: 'var(--color-muted-foreground)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
-                  <th style={{ padding: '4px 8px', textAlign: 'left', fontWeight: 600 }}>Namespace</th>
-                  <Th>Total</Th>
-                  <Th>Running</Th>
-                  <Th>Stopped</Th>
-                  <Th>Crashed</Th>
-                  <Th>Other</Th>
-                </tr>
-              </thead>
-              <tbody>
-                {stats.namespaces.map(ns => (
-                  <tr key={ns.namespace} style={{ borderTop: '1px solid var(--color-border)', fontSize: 13 }}>
-                    <td style={{ padding: '7px 8px', fontWeight: 500 }}>{ns.namespace}</td>
-                    <Td>{ns.total}</Td>
-                    <Td color={ns.running > 0 ? 'var(--color-status-running)' : undefined}>{ns.running}</Td>
-                    <Td color={ns.stopped > 0 ? 'var(--color-status-stopped)' : undefined}>{ns.stopped}</Td>
-                    <Td color={ns.crashed > 0 ? 'var(--color-status-crashed)' : undefined}>{ns.crashed}</Td>
-                    <Td>{ns.other}</Td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 12 }}>
+              {stats.namespaces.map(ns => (
+                <NamespaceCard
+                  key={ns.namespace}
+                  ns={ns}
+                  onNavigate={() => navigate(`/namespace/${encodeURIComponent(ns.namespace)}`)}
+                  onStartAll={() => startNamespace(ns.namespace)}
+                />
+              ))}
+            </div>
           </div>
         )}
 
@@ -279,6 +272,9 @@ export default function AnalyticsPage({ processes, settings }: Props) {
             )}
           </div>
         </div>
+
+        {/* Row 5: Log volume history charts */}
+        <LogStatsSection processes={processes} />
 
         {/* Empty state */}
         {processes.length === 0 && (
@@ -394,13 +390,205 @@ function ProcessRow({ label, sub, dotColor, rank, metric, metricColor, onClick }
   )
 }
 
-// @group BusinessLogic > Th / Td : Table header and data cell helpers
-function Th({ children }: { children: ReactNode }) {
-  return <th style={{ padding: '4px 8px', textAlign: 'right', fontWeight: 600 }}>{children}</th>
+// @group BusinessLogic > NamespaceCard : Clickable namespace row with stacked bar chart and actions
+function NamespaceCard({ ns, onNavigate, onStartAll }: {
+  ns: NamespaceRow
+  onNavigate: () => void
+  onStartAll: () => void
+}) {
+  const hasStopped = ns.stopped > 0 || ns.crashed > 0
+  return (
+    <div
+      onClick={onNavigate}
+      style={{ padding: '10px 12px', borderRadius: 6, border: '1px solid var(--color-border)', cursor: 'pointer' }}
+      onMouseEnter={e => (e.currentTarget.style.background = 'var(--color-accent)')}
+      onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 7 }}>
+        <span style={{ fontWeight: 600, fontSize: 13, flex: 1 }}>{ns.namespace}</span>
+        <span style={{ fontSize: 11, color: 'var(--color-muted-foreground)' }}>
+          {ns.total} process{ns.total !== 1 ? 'es' : ''}
+        </span>
+        <span style={{ display: 'flex', gap: 10, fontSize: 11 }}>
+          {ns.running > 0 && <span style={{ color: 'var(--color-status-running)'  }}>{ns.running} running</span>}
+          {ns.other   > 0 && <span style={{ color: 'var(--color-status-sleeping)' }}>{ns.other} other</span>}
+          {ns.stopped > 0 && <span style={{ color: 'var(--color-status-stopped)'  }}>{ns.stopped} stopped</span>}
+          {ns.crashed > 0 && <span style={{ color: 'var(--color-status-crashed)'  }}>{ns.crashed} crashed</span>}
+        </span>
+        {hasStopped && (
+          <button
+            onClick={e => { e.stopPropagation(); onStartAll() }}
+            style={{
+              padding: '2px 8px', fontSize: 11, fontWeight: 600,
+              background: 'transparent', border: '1px solid var(--color-border)',
+              borderRadius: 4, cursor: 'pointer', color: 'var(--color-foreground)',
+              flexShrink: 0,
+            }}
+          >
+            ▶ Start All
+          </button>
+        )}
+      </div>
+      {/* Stacked bar showing running / other / stopped / crashed proportions */}
+      <div style={{ height: 6, display: 'flex', borderRadius: 3, overflow: 'hidden', background: 'var(--color-border)' }}>
+        {ns.running > 0 && <div style={{ flex: ns.running, background: 'var(--color-status-running)'  }} />}
+        {ns.other   > 0 && <div style={{ flex: ns.other,   background: 'var(--color-status-sleeping)' }} />}
+        {ns.stopped > 0 && <div style={{ flex: ns.stopped, background: 'var(--color-status-stopped)'  }} />}
+        {ns.crashed > 0 && <div style={{ flex: ns.crashed, background: 'var(--color-status-crashed)'  }} />}
+      </div>
+    </div>
+  )
 }
 
-function Td({ children, color }: { children: ReactNode; color?: string }) {
-  return <td style={{ padding: '7px 8px', textAlign: 'right', color: color ?? 'var(--color-foreground)' }}>{children}</td>
+// @group BusinessLogic > LogStatsSection : Fetches and renders 5-min log volume bar charts for all processes
+function LogStatsSection({ processes }: { processes: ProcessInfo[] }) {
+  const [statsMap, setStatsMap] = useState<Record<string, LogStatsBucket[]>>({})
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  // Fetch all processes (not just running — stopped ones may still have history)
+  const ids = useMemo(() => processes.map(p => p.id).join(','), [processes])
+
+  useEffect(() => {
+    if (processes.length === 0) return
+
+    async function fetchAll() {
+      const entries = await Promise.all(
+        processes.map(p =>
+          api.getLogStats(p.id)
+            .then(r => [p.id, r.buckets] as const)
+            .catch(() => [p.id, []] as const)
+        )
+      )
+      setStatsMap(Object.fromEntries(entries))
+    }
+
+    fetchAll()
+    timerRef.current = setInterval(fetchAll, 60_000)
+    return () => { if (timerRef.current) clearInterval(timerRef.current) }
+  }, [ids])
+
+  // Only show processes that have at least one bucket of data
+  const withData = processes.filter(p => (statsMap[p.id]?.length ?? 0) > 0)
+
+  if (withData.length === 0) return null
+
+  return (
+    <div style={cardStyle}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
+        <div style={cardHeaderStyle}>Log Volume · 5-min intervals</div>
+        <div style={{ display: 'flex', gap: 12, fontSize: 11 }}>
+          <span style={{ display: 'flex', alignItems: 'center', gap: 4, color: 'var(--color-muted-foreground)' }}>
+            <span style={{ width: 8, height: 8, borderRadius: 2, background: 'var(--color-status-running)', display: 'inline-block' }} />
+            stdout
+          </span>
+          <span style={{ display: 'flex', alignItems: 'center', gap: 4, color: 'var(--color-muted-foreground)' }}>
+            <span style={{ width: 8, height: 8, borderRadius: 2, background: 'var(--color-status-crashed)', display: 'inline-block' }} />
+            stderr
+          </span>
+        </div>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))', gap: 12 }}>
+        {withData.map(p => (
+          <LogStatsCard key={p.id} process={p} buckets={statsMap[p.id] ?? []} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// @group BusinessLogic > LogStatsCard : Per-process bar chart of stdout + stderr counts per 5-min bucket
+function LogStatsCard({ process, buckets }: { process: ProcessInfo; buckets: LogStatsBucket[] }) {
+  const maxCount = Math.max(...buckets.map(b => b.stdout_count + b.stderr_count), 1)
+  const totalOut = buckets.reduce((s, b) => s + b.stdout_count, 0)
+  const totalErr = buckets.reduce((s, b) => s + b.stderr_count, 0)
+
+  return (
+    <div style={{
+      border: '1px solid var(--color-border)', borderRadius: 6, padding: '10px 12px',
+      background: 'var(--color-background)', display: 'flex', flexDirection: 'column', gap: 8,
+    }}>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        <span style={{ color: statusColor(process.status), fontSize: 9 }}>●</span>
+        <span style={{ fontWeight: 600, fontSize: 13, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {process.name}
+        </span>
+        <span style={{ fontSize: 11, color: 'var(--color-status-running)', fontWeight: 600 }}>{totalOut} out</span>
+        <span style={{ fontSize: 11, color: 'var(--color-muted-foreground)' }}>·</span>
+        <span style={{ fontSize: 11, color: 'var(--color-status-crashed)', fontWeight: 600 }}>{totalErr} err</span>
+      </div>
+
+      {/* Bar chart */}
+      <LogBarChart buckets={buckets} maxCount={maxCount} />
+
+      {/* Time labels */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 10, color: 'var(--color-muted-foreground)' }}>
+        <span>{fmtBucketTime(buckets[0]?.window_start)}</span>
+        <span>{fmtBucketTime(buckets[buckets.length - 1]?.window_start)}</span>
+      </div>
+    </div>
+  )
+}
+
+// @group BusinessLogic > LogBarChart : Pure-SVG stacked bar chart (stdout green, stderr red)
+function LogBarChart({ buckets, maxCount }: { buckets: LogStatsBucket[]; maxCount: number }) {
+  const W = 320
+  const H = 60
+  const PAD_B = 2  // bottom padding
+  const chartH = H - PAD_B
+  const n = buckets.length
+  if (n === 0) return null
+
+  const barW = Math.max(1, (W / n) - 1)
+  const gap  = Math.max(0, (W / n) - barW)
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} style={{ width: '100%', height: H, display: 'block' }}>
+      {/* 50% guide line */}
+      <line x1={0} y1={chartH / 2} x2={W} y2={chartH / 2}
+        stroke="var(--color-border)" strokeWidth={0.5} strokeDasharray="3 3" />
+
+      {buckets.map((b, i) => {
+        const x = i * (barW + gap)
+        const total = b.stdout_count + b.stderr_count
+        const totalH = (total / maxCount) * chartH
+        const outH   = (b.stdout_count / maxCount) * chartH
+        const errH   = totalH - outH
+
+        return (
+          <g key={i}>
+            {/* stderr (top, red) */}
+            {errH > 0 && (
+              <rect
+                x={x} y={chartH - totalH}
+                width={barW} height={errH}
+                fill="var(--color-status-crashed)"
+                fillOpacity={0.75}
+                rx={1}
+              />
+            )}
+            {/* stdout (bottom, green) */}
+            {outH > 0 && (
+              <rect
+                x={x} y={chartH - outH}
+                width={barW} height={outH}
+                fill="var(--color-status-running)"
+                fillOpacity={0.75}
+                rx={1}
+              />
+            )}
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+// @group Utilities : Format a bucket window_start ISO string into HH:MM
+function fmtBucketTime(iso?: string): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
 }
 
 // @group Constants > Styles : Shared card and header style objects

--- a/web-ui/src/pages/ProcessDetailPage.tsx
+++ b/web-ui/src/pages/ProcessDetailPage.tsx
@@ -8,7 +8,7 @@ import { Dialog } from '@/components/Dialog'
 import { EnvFileModal } from '@/components/EnvFileModal'
 import { statusColor } from '@/lib/utils'
 import type { AppSettings } from '@/lib/settings'
-import type { LogLine, ProcessInfo } from '@/types'
+import type { LogLine, LogStatsBucket, ProcessInfo } from '@/types'
 
 interface Props {
   reload: () => void
@@ -25,6 +25,7 @@ export default function ProcessDetailPage({ reload, settings }: Props) {
   const [streamFilter, setStreamFilter] = useState<'all' | 'stdout' | 'stderr'>('all')
   const [textFilter, setTextFilter] = useState('')
   const [envOpen, setEnvOpen] = useState(false)
+  const [logStats, setLogStats] = useState<LogStatsBucket[]>([])
   const [sliderPos, setSliderPos] = useState(1000) // 0–1000 = 0%–100% of scroll, starts pinned to bottom
   const logEndRef = useRef<HTMLDivElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -47,6 +48,17 @@ export default function ProcessDetailPage({ reload, settings }: Props) {
   useEffect(() => {
     if (!id) return
     api.getLogDates(id).then(d => setLogDates(d.dates)).catch(() => {})
+  }, [id])
+
+  // @group BusinessLogic > LogStats : Fetch today's log volume buckets; refresh every 5 minutes
+  useEffect(() => {
+    if (!id) return
+    function fetchStats() {
+      api.getLogStats(id!).then(r => setLogStats(r.buckets)).catch(() => {})
+    }
+    fetchStats()
+    const t = setInterval(fetchStats, 5 * 60 * 1000)
+    return () => clearInterval(t)
   }, [id])
 
   // Load historical logs + start SSE when dateIndex changes
@@ -304,6 +316,11 @@ export default function ProcessDetailPage({ reload, settings }: Props) {
         )}
       </div>
 
+      {/* Today's log volume chart — shown only when data is available */}
+      {logStats.length > 0 && (
+        <LogVolumeChart buckets={logStats} />
+      )}
+
       {/* Log output */}
       <div ref={scrollRef} onScroll={handleLogScroll} style={{ flex: 1, overflow: 'auto', padding: '10px 16px', background: 'var(--color-background)' }}>
         <div className="log-output">
@@ -369,4 +386,154 @@ const navBtnStyle: React.CSSProperties = {
   padding: '3px 10px', fontSize: 11, background: 'var(--color-secondary)',
   border: '1px solid var(--color-border)', borderRadius: 4, cursor: 'pointer',
   color: 'var(--color-foreground)',
+}
+
+// @group BusinessLogic > LogVolumeChart : Compact full-day stacked bar chart of stdout/stderr counts
+function LogVolumeChart({ buckets }: { buckets: LogStatsBucket[] }) {
+  const [filter, setFilter] = useState<'both' | 'stdout' | 'stderr'>('both')
+
+  const totalOut = buckets.reduce((s, b) => s + b.stdout_count, 0)
+  const totalErr = buckets.reduce((s, b) => s + b.stderr_count, 0)
+
+  const maxCount = Math.max(...buckets.map(b => {
+    if (filter === 'stdout') return b.stdout_count
+    if (filter === 'stderr') return b.stderr_count
+    return b.stdout_count + b.stderr_count
+  }), 1)
+
+  const slots = buildDaySlots(buckets)
+
+  return (
+    <div style={{
+      borderBottom: '1px solid var(--color-border)',
+      background: 'var(--color-card)',
+      padding: '6px 16px 8px',
+      flexShrink: 0,
+    }}>
+      {/* Header row */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 5 }}>
+        <span style={{ color: 'var(--color-muted-foreground)', fontWeight: 600, letterSpacing: '0.05em', textTransform: 'uppercase', fontSize: 10 }}>
+          Log Volume · Today · 5 min intervals
+        </span>
+
+        {/* Filter toggle */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <div style={{ display: 'flex', gap: 2, background: 'var(--color-background)', borderRadius: 6, padding: 2, border: '1px solid var(--color-border)' }}>
+            {(['both', 'stdout', 'stderr'] as const).map(f => (
+              <button key={f} onClick={() => setFilter(f)} style={{
+                padding: '2px 8px', fontSize: 11, fontWeight: 500, borderRadius: 4,
+                border: 'none', cursor: 'pointer', transition: 'background 0.15s',
+                background: filter === f ? 'var(--color-primary)' : 'transparent',
+                color: filter === f
+                  ? 'var(--color-primary-foreground)'
+                  : f === 'stdout'
+                    ? 'var(--color-status-running)'
+                    : f === 'stderr'
+                      ? 'var(--color-status-crashed)'
+                      : 'var(--color-muted-foreground)',
+              }}>
+                {f === 'both' ? 'Both' : f === 'stdout' ? `Out ${totalOut}` : `Err ${totalErr}`}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* SVG bar chart */}
+      <DayBarChart slots={slots} maxCount={maxCount} filter={filter} />
+
+      {/* Time axis labels */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 10, color: 'var(--color-muted-foreground)', marginTop: 3 }}>
+        <span>00:00</span>
+        <span>06:00</span>
+        <span>12:00</span>
+        <span>18:00</span>
+        <span>now</span>
+      </div>
+    </div>
+  )
+}
+
+// @group BusinessLogic > DayBarChart : Pure SVG stacked bar chart spanning all 5-min slots of today
+function DayBarChart({ slots, maxCount, filter }: {
+  slots: Array<{ stdout_count: number; stderr_count: number; isFuture: boolean }>
+  maxCount: number
+  filter: 'both' | 'stdout' | 'stderr'
+}) {
+  const W = 800
+  const H = 48
+  const n = slots.length
+  if (n === 0) return null
+
+  const barW = Math.max(1, (W / n) - 0.5)
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} style={{ width: '100%', height: H, display: 'block' }}>
+      {/* 50% guide */}
+      <line x1={0} y1={H / 2} x2={W} y2={H / 2}
+        stroke="var(--color-border)" strokeWidth={0.5} strokeDasharray="2 4" />
+
+      {slots.map((s, i) => {
+        if (s.isFuture) return null
+        const x = i * (W / n)
+
+        const showOut = filter === 'both' || filter === 'stdout'
+        const showErr = filter === 'both' || filter === 'stderr'
+
+        const outH = showOut ? (s.stdout_count / maxCount) * H : 0
+        const errH = showErr ? (s.stderr_count / maxCount) * H : 0
+        const totalH = outH + errH
+
+        if (totalH < 0.5) return null
+
+        return (
+          <g key={i}>
+            {/* stderr stacked on top */}
+            {errH > 0.5 && (
+              <rect x={x} y={H - totalH} width={barW} height={errH}
+                fill="var(--color-status-crashed)" fillOpacity={0.8} />
+            )}
+            {/* stdout at the bottom */}
+            {outH > 0.5 && (
+              <rect x={x} y={H - outH} width={barW} height={outH}
+                fill="var(--color-status-running)" fillOpacity={0.8} />
+            )}
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+// @group Utilities > LogVolumeChart : Build a full 288-slot grid for today, merging actual bucket data
+function buildDaySlots(buckets: LogStatsBucket[]) {
+  const BUCKET_MS = 5 * 60 * 1000
+  const now = Date.now()
+
+  // Start of today in local time (midnight)
+  const todayMidnight = new Date()
+  todayMidnight.setHours(0, 0, 0, 0)
+  const startMs = todayMidnight.getTime()
+
+  // How many 5-min slots have elapsed since midnight (up to 288)
+  const slotsFilled = Math.min(288, Math.ceil((now - startMs) / BUCKET_MS))
+
+  // Index bucket data by slot index
+  const bySlot = new Map<number, { stdout_count: number; stderr_count: number }>()
+  for (const b of buckets) {
+    const bucketMs = new Date(b.window_start).getTime()
+    const slotIdx  = Math.floor((bucketMs - startMs) / BUCKET_MS)
+    if (slotIdx >= 0 && slotIdx < 288) {
+      bySlot.set(slotIdx, { stdout_count: b.stdout_count, stderr_count: b.stderr_count })
+    }
+  }
+
+  return Array.from({ length: 288 }, (_, i) => {
+    const data = bySlot.get(i)
+    return {
+      stdout_count: data?.stdout_count ?? 0,
+      stderr_count: data?.stderr_count ?? 0,
+      isFuture: i >= slotsFilled,
+    }
+  })
 }

--- a/web-ui/src/pages/ProcessesPage.tsx
+++ b/web-ui/src/pages/ProcessesPage.tsx
@@ -16,10 +16,14 @@ interface Props {
   processes: ProcessInfo[]
   reload: () => void
   settings: AppSettings
+  namespaceFilter?: string
 }
 
 
-export default function ProcessesPage({ processes, reload, settings }: Props) {
+export default function ProcessesPage({ processes, reload, settings, namespaceFilter }: Props) {
+  const displayedProcesses = namespaceFilter
+    ? processes.filter(p => (p.namespace || 'default') === namespaceFilter)
+    : processes
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
   const [envModalProcess, setEnvModalProcess] = useState<ProcessInfo | null>(null)
   const [notifProcess, setNotifProcess]       = useState<ProcessInfo | null>(null)
@@ -51,7 +55,7 @@ export default function ProcessesPage({ processes, reload, settings }: Props) {
   // This handles deep npm/node spawn trees where the actual socket lives 3-4 levels deep.
   const portMap = useMemo(() => {
     const managedPids = new Set(
-      processes.map(p => p.pid).filter((pid): pid is number => pid != null)
+      displayedProcesses.map(p => p.pid).filter((pid): pid is number => pid != null)
     )
     const map = new Map<number, number[]>()
     for (const entry of portData) {
@@ -70,7 +74,7 @@ export default function ProcessesPage({ processes, reload, settings }: Props) {
 
   // Group by namespace
   const groups = new Map<string, ProcessInfo[]>()
-  for (const p of processes) {
+  for (const p of displayedProcesses) {
     const ns = p.namespace || 'default'
     if (!groups.has(ns)) groups.set(ns, [])
     groups.get(ns)!.push(p)
@@ -88,8 +92,7 @@ export default function ProcessesPage({ processes, reload, settings }: Props) {
   }
 
   async function startAll(ns: string) {
-    const targets = (groups.get(ns) ?? []).filter(p => p.status === 'stopped' || p.status === 'crashed' || p.status === 'errored')
-    await Promise.all(targets.map(p => api.startStopped(p.id).catch(() => {})))
+    await api.startNamespace(ns).catch(() => {})
     setTimeout(reload, 300)
   }
 
@@ -97,19 +100,20 @@ export default function ProcessesPage({ processes, reload, settings }: Props) {
     const targets = (groups.get(ns) ?? []).filter(p => p.status === 'running' || p.status === 'watching')
     const ok = await confirm(`Stop all in "${ns}"?`, `${targets.length} running process${targets.length !== 1 ? 'es' : ''} will be stopped.`)
     if (!ok) return
-    await Promise.all(targets.map(p => api.stopProcess(p.id).catch(() => {})))
+    await api.stopNamespace(ns).catch(() => {})
     setTimeout(reload, 400)
   }
 
   async function restartAll(ns: string) {
-    const targets = (groups.get(ns) ?? []).filter(p => p.status === 'running' || p.status === 'watching' || p.status === 'sleeping')
-    await Promise.all(targets.map(p => api.restartProcess(p.id).catch(() => {})))
+    await api.restartNamespace(ns).catch(() => {})
     setTimeout(reload, 400)
   }
 
-  if (!processes.length) {
+  if (!displayedProcesses.length) {
     return (
-      <div style={{ padding: 32, color: 'var(--color-muted-foreground)' }}>No processes registered.</div>
+      <div style={{ padding: 32, color: 'var(--color-muted-foreground)' }}>
+        {namespaceFilter ? `No processes in namespace "${namespaceFilter}".` : 'No processes registered.'}
+      </div>
     )
   }
 
@@ -142,7 +146,19 @@ export default function ProcessesPage({ processes, reload, settings }: Props) {
         {/* Left column: header + scrollable process table */}
         <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, overflow: 'hidden' }}>
           <div style={{ padding: '16px 20px 10px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', borderBottom: '1px solid var(--color-border)', flexShrink: 0 }}>
-            <h2 style={{ fontSize: 16, fontWeight: 600 }}>Processes</h2>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              {namespaceFilter && (
+                <button
+                  onClick={() => navigate('/processes')}
+                  style={{ ...smallBtnStyle, padding: '3px 8px', fontSize: 12 }}
+                >
+                  ← All
+                </button>
+              )}
+              <h2 style={{ fontSize: 16, fontWeight: 600 }}>
+                {namespaceFilter ? <><span style={{ color: 'var(--color-muted-foreground)', fontWeight: 400 }}>ns /</span> {namespaceFilter}</> : 'Processes'}
+              </h2>
+            </div>
             <button onClick={() => { reload(); loadPorts() }} style={smallBtnStyle}>↻ Refresh</button>
           </div>
 

--- a/web-ui/src/pages/SettingsPage.tsx
+++ b/web-ui/src/pages/SettingsPage.tsx
@@ -137,7 +137,7 @@ function CopyPath({ value }: { value: string }) {
 export default function SettingsPage({ settings, onUpdate, onReset }: Props) {
   const isDefault = JSON.stringify(settings) === JSON.stringify(DEFAULT_SETTINGS)
   const [sysPaths, setSysPaths] = useState<{ data_dir: string; log_dir: string } | null>(null)
-  const [activeTab, setActiveTab] = useState<'general' | 'security' | 'ai' | 'telegram'>('general')
+  const [activeTab, setActiveTab] = useState<'general' | 'security' | 'ai' | 'telegram' | 'log-alerts'>('general')
 
   // @group BusinessLogic > AI : Core settings state
   const [aiEnabled, setAiEnabled] = useState(false)
@@ -187,6 +187,14 @@ export default function SettingsPage({ settings, onUpdate, onReset }: Props) {
   const [restarting, setRestarting] = useState(false)
   const [restartStatus, setRestartStatus] = useState<'idle' | 'restarting' | 'done' | 'error'>('idle')
 
+  // @group BusinessLogic > LogAlerts : Log spike alert settings state
+  const [laEnabled, setLaEnabled] = useState(false)
+  const [laThreshold, setLaThreshold] = useState(10)
+  const [laCooldown, setLaCooldown] = useState(15)
+  const [laSaving, setLaSaving] = useState(false)
+  const [laSaved, setLaSaved] = useState(false)
+  const [laError, setLaError] = useState<string | null>(null)
+
   // @group BusinessLogic > Telegram : Bot config state
   const [tgEnabled, setTgEnabled] = useState(false)
   const [tgToken, setTgToken] = useState('')
@@ -205,6 +213,15 @@ export default function SettingsPage({ settings, onUpdate, onReset }: Props) {
   const [tgTesting, setTgTesting] = useState(false)
   const [tgTestResult, setTgTestResult] = useState<string | null>(null)
   const [tgChangingToken, setTgChangingToken] = useState(false)
+
+  // @group BusinessLogic > LogAlerts : Load initial log alert settings
+  useEffect(() => {
+    api.getLogAlerts().then(cfg => {
+      setLaEnabled(cfg.enabled)
+      setLaThreshold(cfg.stderr_threshold)
+      setLaCooldown(cfg.cooldown_mins)
+    }).catch(() => {})
+  }, [])
 
   // @group BusinessLogic > AI : Load initial settings + models on mount
   useEffect(() => {
@@ -584,6 +601,7 @@ export default function SettingsPage({ settings, onUpdate, onReset }: Props) {
         <button style={tabStyle(activeTab === 'security')} onClick={() => setActiveTab('security')}>Security</button>
         <button style={tabStyle(activeTab === 'ai')} onClick={() => setActiveTab('ai')}>AI</button>
         <button style={tabStyle(activeTab === 'telegram')} onClick={() => setActiveTab('telegram')}>Telegram</button>
+        <button style={tabStyle(activeTab === 'log-alerts')} onClick={() => setActiveTab('log-alerts')}>Log Alerts</button>
       </div>
 
       {/* ── Tab: General ── */}
@@ -1430,6 +1448,83 @@ export default function SettingsPage({ settings, onUpdate, onReset }: Props) {
             <p style={{ fontSize: 12, color: 'var(--color-muted-foreground)', marginTop: 12, marginBottom: 0 }}>
               <strong>Commands:</strong> /list · /start &lt;name&gt; · /stop &lt;name&gt; · /restart &lt;name&gt; · /logs &lt;name&gt; [lines] · /status &lt;name&gt; · /ping · /help
             </p>
+          </div>
+        </>
+      )}
+
+      {/* ── Tab: Log Alerts ── */}
+      {activeTab === 'log-alerts' && (
+        <>
+          <p style={sectionTitle}>Log Spike Alerts</p>
+          <div style={card}>
+            <SettingRow
+              label="Enable log alerts"
+              description="Fire a notification when stderr lines in a 5-minute interval exceed the threshold"
+              control={<Toggle checked={laEnabled} onChange={setLaEnabled} />}
+            />
+            <SettingRow
+              label="Stderr threshold"
+              description="Alert when this many stderr lines appear in a single 5-minute bucket"
+              control={
+                <input
+                  type="number" min={1} max={10000} value={laThreshold}
+                  onChange={e => setLaThreshold(Math.max(1, Number(e.target.value)))}
+                  style={{ ...inputStyle, width: 80, textAlign: 'right' }}
+                />
+              }
+            />
+            <SettingRow
+              label="Cooldown"
+              description="Minimum time between repeated alerts for the same process"
+              isLast
+              control={
+                <select
+                  value={laCooldown}
+                  onChange={e => setLaCooldown(Number(e.target.value))}
+                  style={{ ...inputStyle, width: 140 }}
+                >
+                  <option value={5}>5 minutes</option>
+                  <option value={10}>10 minutes</option>
+                  <option value={15}>15 minutes</option>
+                  <option value={30}>30 minutes</option>
+                  <option value={60}>1 hour</option>
+                </select>
+              }
+            />
+          </div>
+
+          <div style={{ ...card, background: 'rgba(var(--color-primary-rgb,99,102,241),0.05)', borderColor: 'rgba(var(--color-primary-rgb,99,102,241),0.2)', marginBottom: 16 }}>
+            <p style={{ fontSize: 12, color: 'var(--color-muted-foreground)', margin: 0, lineHeight: 1.7 }}>
+              Alerts are sent through your configured <strong>Webhook / Slack / Teams</strong> and <strong>Telegram</strong> channels.
+              Make sure at least one is set up in the Notifications or Telegram tabs.
+            </p>
+          </div>
+
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            <button
+              onClick={async () => {
+                setLaSaving(true); setLaSaved(false); setLaError(null)
+                try {
+                  await api.updateLogAlerts({ enabled: laEnabled, stderr_threshold: laThreshold, cooldown_mins: laCooldown })
+                  setLaSaved(true)
+                  setTimeout(() => setLaSaved(false), 2500)
+                } catch (e: unknown) {
+                  setLaError(e instanceof Error ? e.message : 'Save failed')
+                } finally {
+                  setLaSaving(false)
+                }
+              }}
+              disabled={laSaving}
+              style={{
+                padding: '7px 18px', fontSize: 13, fontWeight: 500,
+                background: laSaved ? 'var(--color-status-running)' : 'var(--color-primary)',
+                color: '#fff', border: 'none', borderRadius: 6, cursor: 'pointer',
+                opacity: laSaving ? 0.6 : 1, transition: 'background 0.2s',
+              }}
+            >
+              {laSaved ? 'Saved!' : laSaving ? 'Saving…' : 'Save'}
+            </button>
+            {laError && <span style={{ fontSize: 12, color: 'var(--color-status-crashed)' }}>{laError}</span>}
           </div>
         </>
       )}

--- a/web-ui/src/types.ts
+++ b/web-ui/src/types.ts
@@ -129,3 +129,26 @@ export interface EnvFileEntry {
   name: string
   path: string
 }
+
+// @group Types > Metrics : Single CPU + memory sample returned by the metrics history endpoint
+export interface MetricSample {
+  timestamp: string    // ISO datetime
+  cpu_percent: number
+  memory_bytes: number
+}
+
+// @group Types > LogAlerts : Threshold-based stderr spike notification settings
+export interface LogAlertConfig {
+  enabled: boolean
+  /** Alert when stderr lines in a 5-min bucket reach or exceed this count */
+  stderr_threshold: number
+  /** Minimum minutes between repeated alerts for the same process */
+  cooldown_mins: number
+}
+
+// @group Types > LogStats : One 5-minute bucket of stdout + stderr line counts (from disk)
+export interface LogStatsBucket {
+  window_start: string  // RFC3339 UTC start of the 5-minute window
+  stdout_count: number
+  stderr_count: number
+}


### PR DESCRIPTION
## Summary

Introduces four interconnected features for v0.7.0: rolling process metrics history, stderr log-spike alerting, namespace-level bulk operations, and Telegram command autocomplete.

## Problem

- No way to visualize historical CPU/memory trends per process
- No alerting when a process suddenly floods stderr (e.g. crash loop, misconfiguration)
- Starting/stopping/restarting an entire namespace sent one notification per process, creating noise
- Telegram bot had no command autocomplete, making it harder to discover available commands

## Changes

### Data Models
- Add `MetricSample` struct (CPU percent + memory bytes + timestamp)
- Add `LogStatsBucket` / `DayLogBucket` structs for 5-minute stdout/stderr window counts

### Configuration
- Add `LogAlertConfig`: `enabled`, `stderr_threshold`, `cooldown_mins` — persisted to disk

### Process Manager & Logging
- Track rolling per-process `MetricSample` history in a `VecDeque` (max 288 samples ≈ 2.4 h, sampled every 30 s)
- Add `log_alert_loop`: background task that scans stderr every 5 min and fires `fire_log_alert` on spike
- Add `bulk_suppress` map to suppress per-process notifications during namespace bulk ops
- Add `read_log_stats_today()` in `logging/reader`: buckets today's out/err.log lines by 5-min windows

### Notifications
- `fire_log_alert`: dispatches stderr spike alerts to webhook, Slack, and Teams
- `fire_namespace_event`: sends one aggregated summary notification for bulk namespace ops (replaces per-process noise)

### REST API
- `GET/PUT /log-alerts` — read/write `LogAlertConfig`
- `GET /processes/:id/metrics/history` — rolling CPU + memory samples
- `GET /processes/:id/logs/stats` — full-day 5-min log volume buckets
- `POST /processes/namespace/:ns/start|stop|restart` — bulk namespace operations

### Telegram
- Register all commands with `setMyCommands` for autocomplete on bot startup (re-registers on token change)
- Add `/start ns <ns>`, `/stop ns <ns>`, `/restart ns <ns>` namespace control commands

### Web UI
- `AnalyticsPage`: 5-min log volume chart (stdout vs stderr)
- `ProcessDetailPage`: rolling CPU and memory history charts
- `ProcessesPage`: namespace-level bulk action buttons (start/stop/restart all)
- `SettingsPage`: Log Alerts configuration section (enable toggle, threshold, cooldown)

### Build
- Bump version `0.6.0` → `0.7.0`
- Add `[profile.release-fast]`: thin LTO + 8 codegen units for faster day-to-day release builds